### PR TITLE
PMICDRV-120: Re-enable support for IRQ module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ SOURCES = \
 	src/pmic_common.c \
 	src/pmic_core.c \
 	src/pmic_io.c \
+	src/pmic_irq.c \
 	src/pmic_power.c \
 	src/pmic_wdg.c
 

--- a/include/pmic.h
+++ b/include/pmic.h
@@ -55,6 +55,7 @@
 
 #include "pmic_core.h"
 #include "pmic_io.h"
+#include "pmic_irq.h"
 #include "pmic_wdg.h"
 
 #ifdef __cplusplus
@@ -138,7 +139,9 @@ extern "C" {
 #define PMIC_ST_ERR_INTF_SETUP_FAILED                         (-((int32_t)11))
 #define PMIC_ST_ERR_COMM_INTF_INIT_FAIL                       (-((int32_t)12))
 #define PMIC_ST_ERR_FAIL                                      (-((int32_t)13))
+#define PMIC_ST_ERR_NOT_SUPPORTED                             (-((int32_t)14))
 #define PMIC_ST_WARN_INV_DEVICE_ID                            (-((int32_t)40))
+#define PMIC_ST_WARN_NO_IRQ_REMAINING                         (-((int32_t)41))
 #define PMIC_ST_DEFAULT_DATA                                  (-((int32_t)100))
 /** @} */
 

--- a/include/pmic_common.h
+++ b/include/pmic_common.h
@@ -44,6 +44,11 @@ extern "C" {
 #endif
 
 /*==========================================================================*/
+/*                          Macros and Defines                              */
+/*==========================================================================*/
+#define COUNT(x) (sizeof(x) / sizeof(x[0]))
+
+/*==========================================================================*/
 /*                         Structures and Enums                             */
 /*==========================================================================*/
 typedef struct Pmic_DevSubSysInfo_s {
@@ -111,9 +116,9 @@ static inline void Pmic_setBitField(uint8_t *regData, uint8_t shift, uint8_t mas
     *regData = ((*regData & ~mask) | ((value << shift) & mask));
 }
 
-static inline void Pmic_setBitField_b(uint8_t *regData, uint8_t shift, uint8_t mask, bool value)
+static inline void Pmic_setBitField_b(uint8_t *regData, uint8_t shift, bool value)
 {
-    Pmic_setBitField(regData, shift, mask, value ? 1U : 0U);
+    Pmic_setBitField(regData, shift, (uint8_t)(1U << shift), value ? 1U : 0U);
 }
 
 static inline uint8_t Pmic_getBitField(uint8_t regData, uint8_t shift, uint8_t mask)
@@ -121,9 +126,9 @@ static inline uint8_t Pmic_getBitField(uint8_t regData, uint8_t shift, uint8_t m
     return ((regData & mask) >> shift);
 }
 
-static inline bool Pmic_getBitField_b(uint8_t regData, uint8_t shift, uint8_t mask)
+static inline bool Pmic_getBitField_b(uint8_t regData, uint8_t shift)
 {
-    return Pmic_getBitField(regData, shift, mask) == 1;
+    return Pmic_getBitField(regData, shift, (uint8_t)(1U << shift)) == 1;
 }
 
 #ifdef __cplusplus

--- a/include/pmic_irq.h
+++ b/include/pmic_irq.h
@@ -1,0 +1,341 @@
+/******************************************************************************
+ * Copyright (c) 2024 Texas Instruments Incorporated - http://www.ti.com
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *****************************************************************************/
+
+/**
+ * @file   pmic_irq.h
+ *
+ * @brief  PMIC IRQ Driver API/interface file.
+ */
+
+#ifndef __PMIC_IRQ_H__
+#define __PMIC_IRQ_H__
+
+
+/* ==========================================================================*/
+/*                             Include Files                                 */
+/* ==========================================================================*/
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "pmic_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup Pmic_IRQ PMIC Interrupt Request
+ * @{
+ * @brief Contains definitions related to PMIC IRQ functionality.
+ */
+
+/* ========================================================================== */
+/*                             Macros & Typedefs                              */
+/* ========================================================================== */
+#define PMIC_CFG_REG_CRC_ERR_INT                 (0)
+#define PMIC_NRST_RDBK_ERR_INT                   (1)
+#define PMIC_SAFE_OUT1_RDBK_ERR_INT              (2)
+#define PMIC_EN_OUT_RDBK_ERR_INT                 (3)
+#define PMIC_GPO1_RDBK_ERR_INT                   (4)
+#define PMIC_GPO2_RDBK_ERR_INT                   (5)
+#define PMIC_GPO3_RDBK_ERR_INT                   (6)
+#define PMIC_GPO4_RDBK_ERR_INT                   (7)
+#define PMIC_NORMAL_OFF_INT                      (8)
+#define PMIC_OFF_INT_EVT_ERR_INT                 (9)
+#define PMIC_OFF_PROT_EVT_INT                    (10)
+#define PMIC_FIRST_PWR_ON_INT                    (11)
+#define PMIC_CLK_ERR_INT                         (12)
+#define PMIC_INTERNAL_OV_INT                     (13)
+#define PMIC_INIT_AN_TMO_INT                     (14)
+#define PMIC_CRC_ERR_INT                         (15)
+#define PMIC_SYS_CLK_ERR_PROT_INT                (16)
+#define PMIC_RST_MCU_TMO_INT                     (17)
+#define PMIC_BGXM_ERR_INT                        (18)
+#define PMIC_VBAT_OVP_ERR_INT                    (19)
+#define PMIC_BB_OVP_ERR_INT                      (20)
+#define PMIC_BB_BST_TMO_INT                      (21)
+#define PMIC_BB_PK_ILIM_ERR_INT                  (22)
+#define PMIC_WD_TMO_INT                          (23)
+#define PMIC_WD_TRIG_EARLY_INT                   (24)
+#define PMIC_WD_ANSW_EARLY_INT                   (25)
+#define PMIC_WD_SEQ_ERR_INT                      (26)
+#define PMIC_WD_ANSW_ERR_INT                     (27)
+#define PMIC_WD_LONGWIN_TMO_INT                  (28)
+#define PMIC_WD_TH1_ERR_INT                      (29)
+#define PMIC_WD_TH2_ERR_INT                      (30)
+#define PMIC_ESM_ERR_INT                         (31)
+#define PMIC_ESM_DLY1_ERR_INT                    (32)
+#define PMIC_ESM_DLY2_ERR_INT                    (33)
+#define PMIC_BB_UV_ERR_INT                       (34)
+#define PMIC_BB_OV_ERR_INT                       (35)
+#define PMIC_LDO1_UV_ERR_INT                     (36)
+#define PMIC_LDO1_OV_ERR_INT                     (37)
+#define PMIC_LDO2_UV_ERR_INT                     (38)
+#define PMIC_LDO2_OV_ERR_INT                     (39)
+#define PMIC_LDO3_UV_ERR_INT                     (40)
+#define PMIC_LDO3_OV_ERR_INT                     (41)
+#define PMIC_LDO4_UV_ERR_INT                     (42)
+#define PMIC_LDO4_OV_ERR_INT                     (43)
+#define PMIC_PLDO1_UV_ERR_INT                    (44)
+#define PMIC_PLDO1_OV_ERR_INT                    (45)
+#define PMIC_PLDO2_UV_ERR_INT                    (46)
+#define PMIC_PLDO2_OV_ERR_INT                    (47)
+#define PMIC_EXT_VMON1_UV_ERR_INT                (48)
+#define PMIC_EXT_VMON1_OV_ERR_INT                (49)
+#define PMIC_EXT_VMON2_UV_ERR_INT                (50)
+#define PMIC_EXT_VMON2_OV_ERR_INT                (51)
+#define PMIC_LDO1_ILIM_ERR_INT                   (52)
+#define PMIC_LDO2_ILIM_ERR_INT                   (53)
+#define PMIC_LDO3_ILIM_ERR_INT                   (54)
+#define PMIC_LDO4_ILIM_ERR_INT                   (55)
+#define PMIC_PLDO1_ILIM_ERR_INT                  (56)
+#define PMIC_PLDO2_ILIM_ERR_INT                  (57)
+#define PMIC_BB_AVG_ILIM_ERR_INT                 (58)
+#define PMIC_ABIST_ERR_INT                       (59)
+#define PMIC_LBIST_ERR_INT                       (60)
+#define PMIC_TMR_REG_ERR_INT                     (61)
+#define PMIC_M_PMIC_HB_ERR_INT                   (62)
+#define PMIC_SAFE_ST_TMO_RST_ERR_INT             (63)
+#define PMIC_SPI_CRC_ERR_INT                     (64)
+#define PMIC_FRM_ERR_INT                         (65)
+#define PMIC_ADDR_ERR_INT                        (66)
+#define PMIC_SCLK_ERR_INT                        (67)
+#define PMIC_COMP1_ERR_INT                       (68)
+#define PMIC_COMP1P_UV_ERR_INT                   (69)
+#define PMIC_COMP1P_OV_ERR_INT                   (70)
+#define PMIC_COMP1N_UV_ERR_INT                   (71)
+#define PMIC_COMP1N_OV_ERR_INT                   (72)
+#define PMIC_COMP2_ERR_INT                       (73)
+#define PMIC_COMP2P_UV_ERR_INT                   (74)
+#define PMIC_COMP2P_OV_ERR_INT                   (75)
+#define PMIC_COMP2N_UV_ERR_INT                   (76)
+#define PMIC_COMP2N_OV_ERR_INT                   (77)
+#define PMIC_IRQ_MAX                             (PMIC_COMP2N_OV_ERR_INT)
+#define PMIC_IRQ_NUM                             (PMIC_IRQ_MAX + 1U)
+#define PMIC_IRQ_ALL                             ((uint8_t)0xFFU)
+
+// Defines used internally only
+#define PMIC_NUM_ELEM_IN_INTR_STAT               ((uint8_t)4)
+#define PMIC_NUM_BITS_IN_INTR_STAT               ((uint8_t)(PMIC_NUM_ELEM_IN_INTR_STAT * sizeof(uint32_t)))
+
+/**
+ * @defgroup Pmic_IRQMacros PMIC Interrupt Request Macros
+ * @{
+ * @ingroup Pmic_IRQ
+ * @brief Contains macros used in the IRQ module of PMIC driver.
+ */
+
+#define PMIC_IRQ_CFG_MASK_VALID         (0U)
+#define PMIC_IRQ_CFG_CONFIG_VALID       (1U)
+
+#define PMIC_IRQ_CFG_MASK_VALID_SHIFT   (1U << PMIC_IRQ_CFG_MASK_VALID)
+#define PMIC_IRQ_CFG_CONFIG_VALID_SHIFT (1U << PMIC_IRQ_CFG_CONFIG_VALID)
+#define PMIC_IRQ_CFG_ALL_VALID_SHIFT (\
+    PMIC_IRQ_CFG_MASK_VALID_SHIFT |\
+    PMIC_IRQ_CFG_CONFIG_VALID_SHIFT)
+
+/** * @} */
+/* End of Pmic_IRQMacros */
+
+/*==========================================================================*/
+/*                         Structures and Enums                             */
+/*==========================================================================*/
+
+/**
+ * @defgroup Pmic_IRQStructures PMIC IRQ Structures
+ * @{
+ * @ingroup Pmic_IRQ
+ * @brief Contains structures used in the IRQ module of PMIC driver.
+ */
+
+// TODO: Document this, be sure to note that some IRQs are non-maskable, some
+// are non-configurable, list them. Also note that for validParams, irqNum is
+// always required so does not have a corresponding VP.
+typedef struct Pmic_IrqCfg_s {
+    uint8_t validParams;
+    uint8_t irqNum;
+
+    bool mask;
+    uint8_t config;
+} Pmic_IrqCfg_t;
+
+/**
+ * @brief Structure for storing PMIC interrupt status.
+ * @ingroup Pmic_IRQStructures
+ *
+ * @param intStatus Array to store interrupt status.
+ */
+typedef struct Pmic_IrqStat_s {
+    uint32_t intStat[PMIC_NUM_ELEM_IN_INTR_STAT];
+} Pmic_IrqStat_t;
+
+/** * @} */
+/* End of Pmic_IRQStructures */
+
+/*==========================================================================*/
+/*                         Function Declarations                            */
+/*==========================================================================*/
+
+/**
+ * @defgroup Pmic_IRQFunctions PMIC Interrupt Request Functions
+ * @{
+ * @ingroup Pmic_IRQ
+ * @brief Contains functions used in the IRQ module of PMIC driver.
+ */
+
+/**
+ * @brief Set the configuration for a single PMIC IRQ.
+ *
+ * @param handle [IN] PMIC interface handle.
+ *
+ * @return Success code if IRQ mask configuration(s) have been set, error code
+ * otherwise. For valid success/error codes, refer to @ref Pmic_errorCodes.
+ */
+int32_t Pmic_irqSetCfg(Pmic_CoreHandle_t *handle, const Pmic_IrqCfg_t *irqCfg);
+
+/**
+ * @brief Set the configuration for multiple PMIC IRQs.
+ *
+ * @param handle  [IN] PMIC interface handle.
+ * @param numIrqs [IN] Number of IRQ configurations to set.
+ * @param irqCfg  [IN] Array of IRQ configurations.
+ *
+ * @return Success code if IRQ configuration(s) have been set, error code
+ * otherwise. For valid success/error codes, refer to @ref Pmic_errorCodes.
+ */
+int32_t Pmic_irqSetCfgs(Pmic_CoreHandle_t *handle, uint8_t numIrqs, const Pmic_IrqCfg_t *irqCfg);
+
+/**
+ * @brief Get the mask configuration for a PMIC IRQ.
+ *
+ * @param handle      [IN]     PMIC interface handle.
+ * @param irqMask     [IN/OUT] Array of IRQ mask configurations.
+ *
+ * @return Success code if IRQ mask configuration(s) have been obtained, error
+ * code otherwise. For valid success/error codes, refer to @ref Pmic_errorCodes.
+ */
+int32_t Pmic_irqGetCfg(Pmic_CoreHandle_t *handle, Pmic_IrqCfg_t *irqCfg);
+
+/**
+ * @brief Get the mask configuration for PMIC IRQs.
+ *
+ * @param handle      [IN]     PMIC interface handle.
+ * @param numIrqMasks [IN]     Number of IRQ mask configurations to obtain.
+ * @param irqMasks    [IN/OUT] Array of IRQ mask configurations.
+ *
+ * @return Success code if IRQ mask configuration(s) have been obtained, error
+ * code otherwise. For valid success/error codes, refer to @ref Pmic_errorCodes.
+ */
+int32_t Pmic_irqGetCfgs(Pmic_CoreHandle_t *handle, uint8_t numIrqs, Pmic_IrqCfg_t *irqCfgs);
+
+/**
+ * @brief Get the status of all PMIC IRQs.
+ *
+ * @attention End-user must call this API first before calling `Pmic_irqGetNextFlag()`.
+ *
+ * @param handle  [IN] PMIC interface handle.
+ * @param irqStat [OUT] Status of all PMIC IRQs.
+ *
+ * @return Success code if all PMIC IRQ statuses have been obtained, error code
+ * otherwise. For valid success/error codes, refer to @ref Pmic_errorCodes.
+ */
+int32_t Pmic_irqGetStat(Pmic_CoreHandle_t *handle, Pmic_IrqStat_t *irqStat);
+
+/**
+ * @brief Get the next PMIC IRQ that has its flag set (status bit set to 1).
+ *
+ * @attention End-user must call `Pmic_irqGetStat()` first to get all PMIC IRQ
+ * statuses. Once the IRQ statuses have been obtained, it is passed as input to
+ * this API so that the next IRQ flag can be discovered. Once the next flag is
+ * found, end-user can call `Pmic_irqClrFlag()` to clear the flag.
+ *
+ * @param handle [IN] PMIC interface handle.
+ * @param irqStat [IN/OUT] Status of all PMIC IRQs. Once the next IRQ flag has
+ * been found, the corresponding status bit in struct member `intrStat` will be
+ * cleared.
+ * @param irqNum [OUT] The next IRQ that has its flag set. For valid values,
+ * refer to @ref Pmic_IRQs.
+ *
+ * @return Success code if the next IRQ that has its flag set has been obtained,
+ * error code otherwise. For valid success/error codes, refer to @ref Pmic_errorCodes.
+ */
+int32_t Pmic_irqGetNextFlag(Pmic_IrqStat_t *irqStat, uint8_t *irqNum);
+
+/**
+ * @brief Get the flag status of a specific IRQ.
+ *
+ * @param handle [IN] PMIC interface handle.
+ * @param irqNum [IN] Target PMIC IRQ. For valid values, refer to @ref Pmic_IRQs.
+ * @param flag [OUT] Status flag of the target PMIC IRQ. This parameter returned
+ * as true indicates that the target IRQ's status flag is set to 1. Otherwise,
+ * the target IRQ's status flag is set to 0.
+ *
+ * @return Success code if the PMIC IRQ flag has been obtained, error code
+ * otherwise. For valid success/error codes, refer to @ref Pmic_errorCodes.
+ */
+int32_t Pmic_irqGetFlag(Pmic_CoreHandle_t *handle, uint8_t irqNum, bool *flag);
+
+/**
+ * @brief Clear a specific PMIC IRQ flag.
+ *
+ * @attention This API is meant to be called after getting the next flag status from
+ * `Pmic_irqGetNextFlag()` or getting a specific flag status from `Pmic_irqGetFlag()`
+ *
+ * @param handle [IN] PMIC interface handle.
+ * @param irqNum [IN] Target PMIC IRQ to clear. For valid values, refer to @ref
+ * Pmic_IRQs.
+ *
+ * @return Success code if the PMIC IRQ flag has been cleared, error code
+ * otherwise. For valid success/error codes, refer to @ref Pmic_errorCodes.
+ */
+int32_t Pmic_irqClrFlag(Pmic_CoreHandle_t *handle, uint8_t irqNum);
+
+/**
+ * @brief Clear all PMIC IRQ flags.
+ *
+ * @param handle [IN] PMIC interface handle.
+ *
+ * @return Success code if all PMIC IRQ flags have been cleared, error code
+ * otherwise. For valid success/error codes, refer to @ref Pmic_errorCodes.
+ */
+int32_t Pmic_irqClrAllFlags(Pmic_CoreHandle_t *handle);
+
+/** * @} */
+/* End of Pmic_IRQFunctions */
+/** * @} */
+/* End of Pmic_IRQ */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* __PMIC_IRQ_H__ */

--- a/include/regmap/irq.h
+++ b/include/regmap/irq.h
@@ -1,0 +1,365 @@
+/******************************************************************************
+ * Copyright (c) 2024 Texas Instruments Incorporated - http://www.ti.com
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *****************************************************************************/
+#ifndef __PMIC_REGMAP_IRQ_H__
+#define __PMIC_REGMAP_IRQ_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// IRQ Status Registers
+#define REG_STAT_REG                    ((uint16_t)0x09U)
+#define RDBK_ERR_STAT_REG               ((uint16_t)0x0BU)
+#define OFF_STATE_STAT1_REG             ((uint16_t)0x0FU)
+#define OFF_STATE_STAT2_REG             ((uint16_t)0x10U)
+#define WD_ERR_STAT_REG                 ((uint16_t)0x46U)
+#define ESM_ERR_STAT_REG                ((uint16_t)0x51U)
+#define DCDC_STAT_REG                   ((uint16_t)0x5AU)
+#define VMON_LDO_STAT_REG               ((uint16_t)0x5CU)
+#define VMON_PLDO_STAT_REG              ((uint16_t)0x5EU)
+#define EXT_VMON_STAT_REG               ((uint16_t)0x5FU)
+#define ILIM_STAT_REG                   ((uint16_t)0x62U)
+#define BIST_STAT_REG                   ((uint16_t)0x65U)
+#define DEV_ERR_STAT_REG                ((uint16_t)0x66U)
+#define SPI_ERR_STAT_REG                ((uint16_t)0x67U)
+#define CM_STAT1_REG                    ((uint16_t)0x77U)
+#define CM_STAT2_REG                    ((uint16_t)0x78U)
+
+// IRQ Clear Registers
+#define OFF_STATE_CLR_REG               ((uint16_t)0x11U)
+
+// IRQ Configuration and Mask Registers
+#define SAFETY_CFG_REG                  ((uint16_t)0x07U)
+#define RDBK_INT_MASK_CFG_REG           ((uint16_t)0x0CU)
+#define RDBK_INT_CFG1_REG               ((uint16_t)0x0DU)
+#define RDBK_INT_CFG2_REG               ((uint16_t)0x0EU)
+#define OV_INT_MASK_REG                 ((uint16_t)0x34U)
+#define OV_INT_CFG1_REG                 ((uint16_t)0x35U)
+#define OV_INT_CFG2_REG                 ((uint16_t)0x36U)
+#define OV_DCDC_CFG_REG                 ((uint16_t)0x37U)
+#define UV_INT_MASK_REG                 ((uint16_t)0x38U)
+#define UV_INT_CFG1_REG                 ((uint16_t)0x39U)
+#define UV_INT_CFG2_REG                 ((uint16_t)0x3AU)
+#define UV_DCDC_CFG_REG                 ((uint16_t)0x3BU)
+#define WD_INT_CFG_REG                  ((uint16_t)0x42U)
+#define ESM_INT_CFG_REG                 ((uint16_t)0x4AU)
+#define ILIM_CFG_REG                    ((uint16_t)0x60U)
+#define CM_COMP_INT_MASK_CFG_REG        ((uint16_t)0x79U)
+#define CM_VMON_INT_MASK_CFG_REG        ((uint16_t)0x7AU)
+#define CM_VMON_INT_CFG_REG             ((uint16_t)0x7BU)
+
+// REG_STAT_REG Bit Shifts
+#define CFG_REG_CRC_ERR_SHIFT           (0U)
+
+// RDBK_ERR_STAT_REG Bit Shifts
+#define NRST_RDBK_ERR_SHIFT             (0U)
+#define SAFE_OUT1_RDBK_ERR_SHIFT        (1U)
+#define EN_OUT_RDBK_ERR_SHIFT           (2U)
+#define GPO1_RDBK_ERR_SHIFT             (3U)
+#define GPO2_RDBK_ERR_SHIFT             (4U)
+#define GPO3_RDBK_ERR_SHIFT             (5U)
+#define GPO4_RDBK_ERR_SHIFT             (6U)
+
+// OFF_STATE_STAT1_REG Bit Shifts
+#define NORMAL_OFF_SHIFT                (0U)
+#define OFF_INT_EVT_ERR_SHIFT           (1U)
+#define OFF_PROT_EVT_SHIFT              (2U)
+#define FIRST_PWR_ON_SHIFT              (4U)
+#define CLK_ERR_SHIFT                   (5U)
+#define INTERNAL_OV_SHIFT               (6U)
+#define INIT_AN_TMO_SHIFT               (7U)
+
+// OFF_STATE_STAT2_REG Bit Shifts
+#define CRC_ERR_SHIFT                   (0U)
+#define SYS_CLK_ERR_PROT_SHIFT          (1U)
+#define RST_MCU_TMO_SHIFT               (2U)
+#define BGXM_ERR_SHIFT                  (3U)
+#define VBAT_OVP_ERR_SHIFT              (4U)
+#define BB_OVP_ERR_SHIFT                (5U)
+#define BB_BST_TMO_SHIFT                (6U)
+#define BB_PK_ILIM_ERR_SHIFT            (7U)
+
+// WD_ERR_STAT_REG Bit Shifts
+#define WD_TMO_SHIFT                    (0U)
+#define WD_TRIG_EARLY_SHIFT             (1U)
+#define WD_ANSW_EARLY_SHIFT             (2U)
+#define WD_SEQ_ERR_SHIFT                (3U)
+#define WD_ANSW_ERR_SHIFT               (4U)
+#define WD_LONGWIN_TMO_SHIFT            (5U)
+#define WD_TH1_ERR_SHIFT                (6U)
+#define WD_TH2_ERR_SHIFT                (7U)
+
+// ESM_ERR_STAT_REG Bit Shifts
+#define ESM_ERR_SHIFT                   (5U)
+#define ESM_DLY1_ERR_SHIFT              (6U)
+#define ESM_DLY2_ERR_SHIFT              (7U)
+
+// DCDC_STAT_REG Bit Shifts
+#define BB_UV_ERR_SHIFT                 (0U)
+#define BB_OV_ERR_SHIFT                 (1U)
+
+// VMON_LDO_STAT_REG Bit Shifts
+#define LDO1_UV_ERR_SHIFT               (0U)
+#define LDO1_OV_ERR_SHIFT               (1U)
+#define LDO2_UV_ERR_SHIFT               (2U)
+#define LDO2_OV_ERR_SHIFT               (3U)
+#define LDO3_UV_ERR_SHIFT               (4U)
+#define LDO3_OV_ERR_SHIFT               (5U)
+#define LDO4_UV_ERR_SHIFT               (6U)
+#define LDO4_OV_ERR_SHIFT               (7U)
+
+// VMON_PLDO_STAT_REG Bit Shifts
+#define PLDO1_UV_ERR_SHIFT              (0U)
+#define PLDO1_OV_ERR_SHIFT              (1U)
+#define PLDO2_UV_ERR_SHIFT              (2U)
+#define PLDO2_OV_ERR_SHIFT              (3U)
+
+// EXT_VMON_STAT_REG Bit Shifts
+#define EXT_VMON1_UV_ERR_SHIFT          (0U)
+#define EXT_VMON1_OV_ERR_SHIFT          (1U)
+#define EXT_VMON2_UV_ERR_SHIFT          (2U)
+#define EXT_VMON2_OV_ERR_SHIFT          (3U)
+
+// ILIM_STAT_REG Bit Shifts
+#define LDO1_ILIM_ERR_SHIFT             (0U)
+#define LDO2_ILIM_ERR_SHIFT             (1U)
+#define LDO3_ILIM_ERR_SHIFT             (2U)
+#define LDO4_ILIM_ERR_SHIFT             (3U)
+#define PLDO1_ILIM_ERR_SHIFT            (4U)
+#define PLDO2_ILIM_ERR_SHIFT            (5U)
+#define BB_AVG_ILIM_ERR_SHIFT           (6U)
+
+// BIST_STAT_REG Bit Shifts
+#define ABIST_ERR_SHIFT                 (2U)
+#define LBIST_ERR_SHIFT                 (3U)
+#define TMR_REG_ERR_SHIFT               (4U)
+#define M_PMIC_HB_ERR_SHIFT             (5U)
+
+// DEV_ERR_STAT_REG Bit Shifts
+#define SAFE_ST_TMO_RST_ERR_SHIFT       (7U)
+
+// SPI_ERR_STAT_REG Bit Shifts
+#define SPI_CRC_ERR_SHIFT               (0U)
+#define FRM_ERR_SHIFT                   (1U)
+#define ADDR_ERR_SHIFT                  (2U)
+#define SCLK_ERR_SHIFT                  (3U)
+
+// CM_STAT1_REG Bit Shifts
+#define COMP1_ERR_SHIFT                 (1U)
+#define COMP1P_UV_ERR_SHIFT             (2U)
+#define COMP1P_OV_ERR_SHIFT             (3U)
+#define COMP1N_UV_ERR_SHIFT             (4U)
+#define COMP1N_OV_ERR_SHIFT             (5U)
+
+// CM_STAT2_REG Bit Shifts
+#define COMP2_ERR_SHIFT                 (1U)
+#define COMP2P_UV_ERR_SHIFT             (2U)
+#define COMP2P_OV_ERR_SHIFT             (3U)
+#define COMP2N_UV_ERR_SHIFT             (4U)
+#define COMP2N_OV_ERR_SHIFT             (5U)
+
+// OFF_STATE_CLR_REG Bit Shifts
+#define OFF_STATE_STAT_CLR_SHIFT        (0U)
+
+// SAFETY_CFG_REG Bit Shifts
+#define CFG_REG_CRC_INT_CFG_SHIFT       (6U)
+#define CFG_REG_CRC_INT_CFG_MASK        (1U << CFG_REG_CRC_INT_CFG_SHIFT)
+
+// RDBK_INT_MASK_CFG_REG Bit Shifts
+#define NRST_RDBK_INT_MASK_SHIFT        (0U)
+#define SAFE_OUT1_RDBK_INT_MASK_SHIFT   (1U)
+#define EN_OUT_RDBK_INT_MASK_SHIFT      (2U)
+#define GPO1_RDBK_INT_MASK_SHIFT        (3U)
+#define GPO2_RDBK_INT_MASK_SHIFT        (4U)
+#define GPO3_RDBK_INT_MASK_SHIFT        (5U)
+#define GPO4_RDBK_INT_MASK_SHIFT        (6U)
+
+// RDBK_INT_CFG1_REG Bit Masks and Shifts
+#define NRST_RDBK_INT_CFG_SHIFT         (0U)
+#define SAFE_OUT1_RDBK_INT_CFG_SHIFT    (2U)
+#define EN_OUT_RDBK_INT_CFG_SHIFT       (4U)
+#define NRST_RDBK_INT_CFG_MASK          (0x3U << NRST_RDBK_INT_CFG_SHIFT)
+#define SAFE_OUT1_RDBK_INT_CFG_MASK     (0x3U << SAFE_OUT1_RDBK_INT_CFG_SHIFT)
+#define EN_OUT_RDBK_INT_CFG_MASK        (0x3U << EN_OUT_RDBK_INT_CFG_SHIFT)
+
+// RDBK_INT_CFG2_REG Bit Masks and Shifts
+#define GPO1_RDBK_INT_CFG_SHIFT         (0U)
+#define GPO2_RDBK_INT_CFG_SHIFT         (2U)
+#define GPO3_RDBK_INT_CFG_SHIFT         (4U)
+#define GPO4_RDBK_INT_CFG_SHIFT         (6U)
+#define GPO1_RDBK_INT_CFG_MASK          (0x3U << GPO1_RDBK_INT_CFG_SHIFT)
+#define GPO2_RDBK_INT_CFG_MASK          (0x3U << GPO2_RDBK_INT_CFG_SHIFT)
+#define GPO3_RDBK_INT_CFG_MASK          (0x3U << GPO3_RDBK_INT_CFG_SHIFT)
+#define GPO4_RDBK_INT_CFG_MASK          (0x3U << GPO4_RDBK_INT_CFG_SHIFT)
+
+// OV_INT_MASK_REG Bit Shifts
+#define LDO1_OV_INT_MASK_SHIFT          (0U)
+#define LDO2_OV_INT_MASK_SHIFT          (1U)
+#define LDO3_OV_INT_MASK_SHIFT          (2U)
+#define LDO4_OV_INT_MASK_SHIFT          (3U)
+#define PLDO1_OV_INT_MASK_SHIFT         (4U)
+#define PLDO2_OV_INT_MASK_SHIFT         (5U)
+#define EXT_VMON1_OV_INT_MASK_SHIFT     (6U)
+#define EXT_VMON2_OV_INT_MASK_SHIFT     (7U)
+
+// OV_INT_CFG1_REG Bit Masks and Shifts
+#define LDO1_OV_INT_CFG_SHIFT           (0U)
+#define LDO2_OV_INT_CFG_SHIFT           (2U)
+#define LDO3_OV_INT_CFG_SHIFT           (4U)
+#define LDO4_OV_INT_CFG_SHIFT           (6U)
+#define LDO1_OV_INT_CFG_MASK            (0x3U << LDO1_OV_INT_CFG_SHIFT)
+#define LDO2_OV_INT_CFG_MASK            (0x3U << LDO2_OV_INT_CFG_SHIFT)
+#define LDO3_OV_INT_CFG_MASK            (0x3U << LDO3_OV_INT_CFG_SHIFT)
+#define LDO4_OV_INT_CFG_MASK            (0x3U << LDO4_OV_INT_CFG_SHIFT)
+
+// OV_INT_CFG2_REG Bit Masks and Shifts
+#define PLDO1_OV_INT_CFG_SHIFT          (0U)
+#define PLDO2_OV_INT_CFG_SHIFT          (2U)
+#define EXT_VMON1_OV_INT_CFG_SHIFT      (4U)
+#define EXT_VMON2_OV_INT_CFG_SHIFT      (6U)
+#define PLDO1_OV_INT_CFG_MASK           (0x3U << PLDO1_OV_INT_CFG_SHIFT)
+#define PLDO2_OV_INT_CFG_MASK           (0x3U << PLDO2_OV_INT_CFG_SHIFT)
+#define EXT_VMON1_OV_INT_CFG_MASK       (0x3U << EXT_VMON1_OV_INT_CFG_SHIFT)
+#define EXT_VMON2_OV_INT_CFG_MASK       (0x3U << EXT_VMON2_OV_INT_CFG_SHIFT)
+
+// OV_DCDC_CFG_REG Bit Masks and Shifts
+#define BB_OV_INT_MASK_SHIFT            (0U)
+#define BB_OV_INT_CFG_SHIFT             (1U)
+#define BB_OV_INT_CFG_MASK              (0x3U << BB_OV_INT_CFG_SHIFT)
+
+// UV_INT_MASK_REG Bit Masks and Shifts
+#define LDO1_UV_INT_MASK_SHIFT          (0U)
+#define LDO2_UV_INT_MASK_SHIFT          (1U)
+#define LDO3_UV_INT_MASK_SHIFT          (2U)
+#define LDO4_UV_INT_MASK_SHIFT          (3U)
+#define PLDO1_UV_INT_MASK_SHIFT         (4U)
+#define PLDO2_UV_INT_MASK_SHIFT         (5U)
+#define EXT_VMON1_UV_INT_MASK_SHIFT     (6U)
+#define EXT_VMON2_UV_INT_MASK_SHIFT     (7U)
+
+// UV_INT_CFG1_REG Bit Masks and Shifts
+#define LDO1_UV_INT_CFG_SHIFT           (0U)
+#define LDO2_UV_INT_CFG_SHIFT           (2U)
+#define LDO3_UV_INT_CFG_SHIFT           (4U)
+#define LDO4_UV_INT_CFG_SHIFT           (6U)
+#define LDO1_UV_INT_CFG_MASK            (0x3U << LDO1_UV_INT_CFG_SHIFT)
+#define LDO2_UV_INT_CFG_MASK            (0x3U << LDO2_UV_INT_CFG_SHIFT)
+#define LDO3_UV_INT_CFG_MASK            (0x3U << LDO3_UV_INT_CFG_SHIFT)
+#define LDO4_UV_INT_CFG_MASK            (0x3U << LDO4_UV_INT_CFG_SHIFT)
+
+// UV_INT_CFG2_REG Bit Masks and Shifts
+#define PLDO1_UV_INT_CFG_SHIFT          (0U)
+#define PLDO2_UV_INT_CFG_SHIFT          (2U)
+#define EXT_VMON1_UV_INT_CFG_SHIFT      (4U)
+#define EXT_VMON2_UV_INT_CFG_SHIFT      (6U)
+#define PLDO1_UV_INT_CFG_MASK           (0x3U << PLDO1_UV_INT_CFG_SHIFT)
+#define PLDO2_UV_INT_CFG_MASK           (0x3U << PLDO2_UV_INT_CFG_SHIFT)
+#define EXT_VMON1_UV_INT_CFG_MASK       (0x3U << EXT_VMON1_UV_INT_CFG_SHIFT)
+#define EXT_VMON2_UV_INT_CFG_MASK       (0x3U << EXT_VMON2_UV_INT_CFG_SHIFT)
+
+// UV_DCDC_CFG_REG Bit Masks and Shifts
+#define BB_UV_INT_MASK_SHIFT            (0U)
+#define BB_UV_INT_CFG_SHIFT             (1U)
+#define BB_UV_INT_CFG_MASK              (0x3U << BB_UV_INT_CFG_SHIFT)
+
+// WD_INT_CFG_REG Bit Masks and Shifts
+#define WD_TH1_INT_MASK_SHIFT           (0U)
+#define WD_TH1_INT_CFG_SHIFT            (1U)
+#define WD_TH2_INT_MASK_SHIFT           (4U)
+#define WD_TH2_INT_CFG_SHIFT            (5U)
+#define WD_TH1_INT_CFG_MASK             (0x3U << WD_TH1_INT_CFG_SHIFT)
+#define WD_TH2_INT_CFG_MASK             (0x3U << WD_TH2_INT_CFG_SHIFT)
+
+// ESM_INT_CFG_REG Bit Masks and Shifts
+#define ESM_INT_MASK_SHIFT              (0U)
+#define ESM_DLY1_INT_MASK_SHIFT         (1U)
+#define ESM_DLY1_INT_CFG_SHIFT          (2U)
+#define ESM_DLY2_INT_MASK_SHIFT         (4U)
+#define ESM_DLY2_INT_CFG_SHIFT          (5U)
+#define ESM_DLY1_INT_CFG_MASK           (0x3U << ESM_DLY1_INT_CFG_SHIFT)
+#define ESM_DLY2_INT_CFG_MASK           (0x3U << ESM_DLY2_INT_CFG_SHIFT)
+
+// ILIM_CFG_REG Bit Masks and Shifts
+#define LDO1_ILIM_CFG_SHIFT             (0U)
+#define LDO2_ILIM_CFG_SHIFT             (1U)
+#define LDO3_ILIM_CFG_SHIFT             (2U)
+#define LDO4_ILIM_CFG_SHIFT             (3U)
+#define PLDO1_ILIM_CFG_SHIFT            (4U)
+#define PLDO2_ILIM_CFG_SHIFT            (5U)
+#define LDO1_ILIM_CFG_MASK              (1U << LDO1_ILIM_CFG_SHIFT)
+#define LDO2_ILIM_CFG_MASK              (1U << LDO2_ILIM_CFG_SHIFT)
+#define LDO3_ILIM_CFG_MASK              (1U << LDO3_ILIM_CFG_SHIFT)
+#define LDO4_ILIM_CFG_MASK              (1U << LDO4_ILIM_CFG_SHIFT)
+#define PLDO1_ILIM_CFG_MASK             (1U << PLDO1_ILIM_CFG_SHIFT)
+#define PLDO2_ILIM_CFG_MASK             (1U << PLDO2_ILIM_CFG_SHIFT)
+
+// CM_COMP_INT_MASK_CFG_REG Bit Masks and Shifts
+#define COMP1_INT_MASK_SHIFT            (0U)
+#define COMP2_INT_MASK_SHIFT            (1U)
+#define COMP1_INT_CFG_SHIFT             (4U)
+#define COMP2_INT_CFG_SHIFT             (6U)
+#define COMP1_INT_CFG_MASK              (0x3U << COMP1_INT_CFG_SHIFT)
+#define COMP2_INT_CFG_MASK              (0x3U << COMP1_INT_CFG_SHIFT)
+
+// CM_VMON_INT_MASK_CFG_REG Bit Masks and Shifts
+#define COMP1P_UV_INT_MASK_SHIFT        (0U)
+#define COMP1P_OV_INT_MASK_SHIFT        (1U)
+#define COMP1N_UV_INT_MASK_SHIFT        (2U)
+#define COMP1N_OV_INT_MASK_SHIFT        (3U)
+#define COMP2P_UV_INT_MASK_SHIFT        (4U)
+#define COMP2P_OV_INT_MASK_SHIFT        (5U)
+#define COMP2N_UV_INT_MASK_SHIFT        (6U)
+#define COMP2N_OV_INT_MASK_SHIFT        (7U)
+
+// CM_VMON_INT_CFG_REG Bit Masks and Shifts
+#define COMP1P_UV_INT_CFG_SHIFT         (0U)
+#define COMP1P_OV_INT_CFG_SHIFT         (1U)
+#define COMP1N_UV_INT_CFG_SHIFT         (2U)
+#define COMP1N_OV_INT_CFG_SHIFT         (3U)
+#define COMP2P_UV_INT_CFG_SHIFT         (4U)
+#define COMP2P_OV_INT_CFG_SHIFT         (5U)
+#define COMP2N_UV_INT_CFG_SHIFT         (6U)
+#define COMP2N_OV_INT_CFG_SHIFT         (7U)
+#define COMP1P_UV_INT_CFG_MASK          (1U << COMP1P_UV_INT_CFG_SHIFT)
+#define COMP1P_OV_INT_CFG_MASK          (1U << COMP1P_OV_INT_CFG_SHIFT)
+#define COMP1N_UV_INT_CFG_MASK          (1U << COMP1N_UV_INT_CFG_SHIFT)
+#define COMP1N_OV_INT_CFG_MASK          (1U << COMP1N_OV_INT_CFG_SHIFT)
+#define COMP2P_UV_INT_CFG_MASK          (1U << COMP2P_UV_INT_CFG_SHIFT)
+#define COMP2P_OV_INT_CFG_MASK          (1U << COMP2P_OV_INT_CFG_SHIFT)
+#define COMP2N_UV_INT_CFG_MASK          (1U << COMP2N_UV_INT_CFG_SHIFT)
+#define COMP2N_OV_INT_CFG_MASK          (1U << COMP2N_OV_INT_CFG_SHIFT)
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __PMIC_REGMAP_IRQ_H__ */

--- a/src/pmic_core.c
+++ b/src/pmic_core.c
@@ -149,11 +149,11 @@ int32_t Pmic_getLockCfg(Pmic_CoreHandle_t *handle, Pmic_Lock_t *config) {
 
     // Extract requested bitfields from register data
     if (Pmic_validParamStatusCheck(config->validParams, PMIC_CFG_REG_LOCK_VALID, status)) {
-        config->cfgLock = Pmic_getBitField_b(regData, CFG_REG_LOCKED_SHIFT, CFG_REG_LOCKED_MASK);
+        config->cfgLock = Pmic_getBitField_b(regData, CFG_REG_LOCKED_SHIFT);
     }
 
     if (Pmic_validParamStatusCheck(config->validParams, PMIC_CFG_CNT_LOCK_VALID, status)) {
-        config->cntLock = Pmic_getBitField_b(regData, CNT_REG_LOCKED_SHIFT, CNT_REG_LOCKED_MASK);
+        config->cntLock = Pmic_getBitField_b(regData, CNT_REG_LOCKED_SHIFT);
     }
 
     return status;

--- a/src/pmic_irq.c
+++ b/src/pmic_irq.c
@@ -1,0 +1,1175 @@
+/******************************************************************************
+ * Copyright (c) 2024 Texas Instruments Incorporated - http://www.ti.com
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *****************************************************************************/
+
+/**
+ * @file   pmic_irq.c
+ *
+ * @brief  This file contains the TPS65386 BB(Black-Bird) PMIC Interrupt APIs
+ * definitions and structures.
+ *
+ */
+
+/* ========================================================================== */
+/*                             Include Files                                  */
+/* ========================================================================== */
+#include <stddef.h>
+#include <stdint.h>
+
+#include "pmic.h"
+#include "pmic_common.h"
+#include "pmic_io.h"
+
+#include "pmic_irq.h"
+#include "regmap/irq.h"
+
+/* ========================================================================== */
+/*                           Macros & Typedefs                                */
+/* ========================================================================== */
+// PMIC IRQ invalid macros
+#define PMIC_IRQ_INVALID_REG              ((uint16_t)0xFFFFU)
+#define PMIC_IRQ_INVALID_MASK_SHIFT       ((uint8_t)0xFFU)
+
+// Number of R/W1C status registers supported on this device
+#define NUM_STAT_REGISTERS (16U)
+#define NUM_MASK_REGISTERS (7U)
+#define NUM_CONF_REGISTERS (13U)
+
+// Helper macros for defining IRQ register/shift/mask linkages
+#define IRQ_DEF_STD(sr, mr, ss, ms, cr, cs, cm) { sr, mr, ss, ms, cr, cs, cm }
+#define IRQ_DEF_NMI_CFG(sr, ss, cr, cs, cm) {\
+    sr, PMIC_IRQ_INVALID_REG, ss, PMIC_IRQ_INVALID_MASK_SHIFT,\
+    cr, cs, cm }
+#define IRQ_DEF_NMI_NCFG(sr, ss) {\
+    sr, PMIC_IRQ_INVALID_REG, ss, PMIC_IRQ_INVALID_MASK_SHIFT,\
+    PMIC_IRQ_INVALID_REG, PMIC_IRQ_INVALID_MASK_SHIFT, PMIC_IRQ_INVALID_MASK_SHIFT }
+
+/* ========================================================================== */
+/*                         Structure Declarations                             */
+/* ========================================================================== */
+typedef struct Pmic_IrqInfo_s {
+    uint16_t statReg;
+    uint16_t maskReg;
+    uint8_t statShift;
+    uint8_t maskShift;
+
+    uint16_t confReg;
+    uint8_t confShift;
+    uint8_t confMask;
+} Pmic_IrqInfo_t;
+
+/* ========================================================================== */
+/*                           Variables and Data                               */
+/* ========================================================================== */
+/* PMIC TPS65386x Interrupt Configuration as per Pmic_tps65386x_IrqNum. */
+static const Pmic_IrqInfo_t IRQ[] = {
+    // PMIC_CFG_REG_CRC_ERR_INT
+    IRQ_DEF_NMI_CFG(REG_STAT_REG,
+                    CFG_REG_CRC_ERR_SHIFT,
+                    SAFETY_CFG_REG,
+                    CFG_REG_CRC_INT_CFG_SHIFT,
+                    CFG_REG_CRC_INT_CFG_MASK),
+    // PMIC_NRST_RDBK_ERR_INT
+    IRQ_DEF_STD(RDBK_ERR_STAT_REG,
+                RDBK_INT_MASK_CFG_REG,
+                NRST_RDBK_ERR_SHIFT,
+                NRST_RDBK_INT_MASK_SHIFT,
+                RDBK_INT_CFG1_REG,
+                NRST_RDBK_INT_CFG_SHIFT,
+                NRST_RDBK_INT_CFG_MASK),
+    // PMIC_SAFE_OUT1_RDBK_ERR_INT
+    IRQ_DEF_STD(RDBK_ERR_STAT_REG,
+                RDBK_INT_MASK_CFG_REG,
+                SAFE_OUT1_RDBK_ERR_SHIFT,
+                SAFE_OUT1_RDBK_INT_MASK_SHIFT,
+                RDBK_INT_CFG1_REG,
+                SAFE_OUT1_RDBK_INT_CFG_SHIFT,
+                SAFE_OUT1_RDBK_INT_CFG_MASK),
+    // PMIC_EN_OUT_RDBK_ERR_INT
+    IRQ_DEF_STD(RDBK_ERR_STAT_REG,
+                RDBK_INT_MASK_CFG_REG,
+                EN_OUT_RDBK_ERR_SHIFT,
+                EN_OUT_RDBK_INT_MASK_SHIFT,
+                RDBK_INT_CFG1_REG,
+                EN_OUT_RDBK_INT_CFG_SHIFT,
+                EN_OUT_RDBK_INT_CFG_MASK),
+    // PMIC_GPO1_RDBK_ERR_INT
+    IRQ_DEF_STD(RDBK_ERR_STAT_REG,
+                RDBK_INT_MASK_CFG_REG,
+                GPO1_RDBK_ERR_SHIFT,
+                GPO1_RDBK_INT_MASK_SHIFT,
+                RDBK_INT_CFG2_REG,
+                GPO1_RDBK_INT_CFG_SHIFT,
+                GPO1_RDBK_INT_CFG_MASK),
+    // PMIC_GPO2_RDBK_ERR_INT
+    IRQ_DEF_STD(RDBK_ERR_STAT_REG,
+                RDBK_INT_MASK_CFG_REG,
+                GPO2_RDBK_ERR_SHIFT,
+                GPO2_RDBK_INT_MASK_SHIFT,
+                RDBK_INT_CFG2_REG,
+                GPO2_RDBK_INT_CFG_SHIFT,
+                GPO2_RDBK_INT_CFG_MASK),
+    // PMIC_GPO3_RDBK_ERR_INT
+    IRQ_DEF_STD(RDBK_ERR_STAT_REG,
+                RDBK_INT_MASK_CFG_REG,
+                GPO3_RDBK_ERR_SHIFT,
+                GPO3_RDBK_INT_MASK_SHIFT,
+                RDBK_INT_CFG2_REG,
+                GPO3_RDBK_INT_CFG_SHIFT,
+                GPO3_RDBK_INT_CFG_MASK),
+    // PMIC_GPO4_RDBK_ERR_INT
+    IRQ_DEF_STD(RDBK_ERR_STAT_REG,
+                RDBK_INT_MASK_CFG_REG,
+                GPO4_RDBK_ERR_SHIFT,
+                GPO4_RDBK_INT_MASK_SHIFT,
+                RDBK_INT_CFG2_REG,
+                GPO4_RDBK_INT_CFG_SHIFT,
+                GPO4_RDBK_INT_CFG_MASK),
+    // PMIC_NORMAL_OFF_INT
+    IRQ_DEF_NMI_NCFG(OFF_STATE_STAT1_REG, NORMAL_OFF_SHIFT),
+    // PMIC_OFF_INT_EVT_ERR_INT
+    IRQ_DEF_NMI_NCFG(OFF_STATE_STAT1_REG, OFF_INT_EVT_ERR_SHIFT),
+    // PMIC_OFF_PROT_EVT_INT
+    IRQ_DEF_NMI_NCFG(OFF_STATE_STAT1_REG, OFF_PROT_EVT_SHIFT),
+    // PMIC_FIRST_PWR_ON_INT
+    IRQ_DEF_NMI_NCFG(OFF_STATE_STAT1_REG, FIRST_PWR_ON_SHIFT),
+    // PMIC_CLK_ERR_INT
+    IRQ_DEF_NMI_NCFG(OFF_STATE_STAT1_REG, CLK_ERR_SHIFT),
+    // PMIC_INTERNAL_OV_INT
+    IRQ_DEF_NMI_NCFG(OFF_STATE_STAT1_REG, INTERNAL_OV_SHIFT),
+    // PMIC_INIT_AN_TMO_INT
+    IRQ_DEF_NMI_NCFG(OFF_STATE_STAT1_REG, INIT_AN_TMO_SHIFT),
+    // PMIC_CRC_ERR_INT
+    IRQ_DEF_NMI_NCFG(OFF_STATE_STAT2_REG, CRC_ERR_SHIFT),
+    // PMIC_SYS_CLK_ERR_PROT_INT
+    IRQ_DEF_NMI_NCFG(OFF_STATE_STAT2_REG, SYS_CLK_ERR_PROT_SHIFT),
+    // PMIC_RST_MCU_TMO_INT
+    IRQ_DEF_NMI_NCFG(OFF_STATE_STAT2_REG, RST_MCU_TMO_SHIFT),
+    // PMIC_BGXM_ERR_INT
+    IRQ_DEF_NMI_NCFG(OFF_STATE_STAT2_REG, BGXM_ERR_SHIFT),
+    // PMIC_VBAT_OVP_ERR_INT
+    IRQ_DEF_NMI_NCFG(OFF_STATE_STAT2_REG, VBAT_OVP_ERR_SHIFT),
+    // PMIC_BB_OVP_ERR_INT
+    IRQ_DEF_NMI_NCFG(OFF_STATE_STAT2_REG, BB_OVP_ERR_SHIFT),
+    // PMIC_BB_BST_TMO_INT
+    IRQ_DEF_NMI_NCFG(OFF_STATE_STAT2_REG, BB_BST_TMO_SHIFT),
+    // PMIC_BB_PK_ILIM_ERR_INT
+    IRQ_DEF_NMI_NCFG(OFF_STATE_STAT2_REG, BB_PK_ILIM_ERR_SHIFT),
+    // PMIC_WD_TMO_INT
+    IRQ_DEF_NMI_NCFG(WD_ERR_STAT_REG, WD_TMO_SHIFT),
+    // PMIC_WD_TRIG_EARLY_INT
+    IRQ_DEF_NMI_NCFG(WD_ERR_STAT_REG, WD_TRIG_EARLY_SHIFT),
+    // PMIC_WD_ANSW_EARLY_INT
+    IRQ_DEF_NMI_NCFG(WD_ERR_STAT_REG, WD_ANSW_EARLY_SHIFT),
+    // PMIC_WD_SEQ_ERR_INT
+    IRQ_DEF_NMI_NCFG(WD_ERR_STAT_REG, WD_SEQ_ERR_SHIFT),
+    // PMIC_WD_ANSW_ERR_INT
+    IRQ_DEF_NMI_NCFG(WD_ERR_STAT_REG, WD_ANSW_ERR_SHIFT),
+    // PMIC_WD_LONGWIN_TMO_INT
+    IRQ_DEF_NMI_NCFG(WD_ERR_STAT_REG, WD_LONGWIN_TMO_SHIFT),
+    // PMIC_WD_TH1_ERR_INT
+    IRQ_DEF_STD(WD_ERR_STAT_REG,
+                WD_INT_CFG_REG,
+                WD_TH1_ERR_SHIFT,
+                WD_TH1_INT_MASK_SHIFT,
+                WD_INT_CFG_REG,
+                WD_TH1_INT_CFG_SHIFT,
+                WD_TH1_INT_CFG_MASK),
+    // PMIC_WD_TH2_ERR_INT
+    IRQ_DEF_STD(WD_ERR_STAT_REG,
+                WD_INT_CFG_REG,
+                WD_TH2_ERR_SHIFT,
+                WD_TH2_INT_MASK_SHIFT,
+                WD_INT_CFG_REG,
+                WD_TH2_INT_CFG_SHIFT,
+                WD_TH2_INT_CFG_MASK),
+    // PMIC_ESM_ERR_INT
+    IRQ_DEF_NMI_NCFG(ESM_ERR_STAT_REG, ESM_ERR_SHIFT),
+    // PMIC_ESM_DLY1_ERR_INT
+    IRQ_DEF_STD(ESM_ERR_STAT_REG,
+                ESM_INT_CFG_REG,
+                ESM_DLY1_ERR_SHIFT,
+                ESM_DLY1_INT_MASK_SHIFT,
+                ESM_INT_CFG_REG,
+                ESM_DLY1_INT_CFG_SHIFT,
+                ESM_DLY1_INT_CFG_MASK),
+    // PMIC_ESM_DLY2_ERR_INT
+    IRQ_DEF_STD(ESM_ERR_STAT_REG,
+                ESM_INT_CFG_REG,
+                ESM_DLY2_ERR_SHIFT,
+                ESM_DLY2_INT_MASK_SHIFT,
+                ESM_INT_CFG_REG,
+                ESM_DLY2_INT_CFG_SHIFT,
+                ESM_DLY2_INT_CFG_MASK),
+    // PMIC_BB_UV_ERR_INT
+    IRQ_DEF_STD(DCDC_STAT_REG,
+                UV_DCDC_CFG_REG,
+                BB_UV_ERR_SHIFT,
+                BB_UV_INT_MASK_SHIFT,
+                UV_DCDC_CFG_REG,
+                BB_UV_INT_CFG_SHIFT,
+                BB_UV_INT_CFG_MASK),
+    // PMIC_BB_OV_ERR_INT
+    IRQ_DEF_STD(DCDC_STAT_REG,
+                OV_DCDC_CFG_REG,
+                BB_OV_ERR_SHIFT,
+                BB_OV_INT_MASK_SHIFT,
+                OV_DCDC_CFG_REG,
+                BB_OV_INT_CFG_SHIFT,
+                BB_OV_INT_CFG_MASK),
+    // PMIC_LDO1_UV_ERR_INT
+    IRQ_DEF_STD(VMON_LDO_STAT_REG,
+                UV_INT_MASK_REG,
+                LDO1_UV_ERR_SHIFT,
+                LDO1_UV_INT_MASK_SHIFT,
+                UV_INT_CFG1_REG,
+                LDO1_UV_INT_CFG_SHIFT,
+                LDO1_UV_INT_CFG_MASK),
+    // PMIC_LDO1_OV_ERR_INT
+    IRQ_DEF_STD(VMON_LDO_STAT_REG,
+                OV_INT_MASK_REG,
+                LDO1_OV_ERR_SHIFT,
+                LDO1_OV_INT_MASK_SHIFT,
+                OV_INT_CFG1_REG,
+                LDO1_OV_INT_CFG_SHIFT,
+                LDO1_OV_INT_CFG_MASK),
+    // PMIC_LDO2_UV_ERR_INT
+    IRQ_DEF_STD(VMON_LDO_STAT_REG,
+                UV_INT_MASK_REG,
+                LDO2_UV_ERR_SHIFT,
+                LDO2_UV_INT_MASK_SHIFT,
+                UV_INT_CFG1_REG,
+                LDO2_UV_INT_CFG_SHIFT,
+                LDO2_UV_INT_CFG_MASK),
+    // PMIC_LDO2_OV_ERR_INT
+    IRQ_DEF_STD(VMON_LDO_STAT_REG,
+                OV_INT_MASK_REG,
+                LDO2_OV_ERR_SHIFT,
+                LDO2_OV_INT_MASK_SHIFT,
+                OV_INT_CFG1_REG,
+                LDO2_OV_INT_CFG_SHIFT,
+                LDO2_OV_INT_CFG_MASK),
+    // PMIC_LDO3_UV_ERR_INT
+    IRQ_DEF_STD(VMON_LDO_STAT_REG,
+                UV_INT_MASK_REG,
+                LDO3_UV_ERR_SHIFT,
+                LDO3_UV_INT_MASK_SHIFT,
+                UV_INT_CFG1_REG,
+                LDO3_UV_INT_CFG_SHIFT,
+                LDO3_UV_INT_CFG_MASK),
+    // PMIC_LDO3_OV_ERR_INT
+    IRQ_DEF_STD(VMON_LDO_STAT_REG,
+                OV_INT_MASK_REG,
+                LDO3_OV_ERR_SHIFT,
+                LDO3_OV_INT_MASK_SHIFT,
+                OV_INT_CFG1_REG,
+                LDO3_OV_INT_CFG_SHIFT,
+                LDO3_OV_INT_CFG_MASK),
+    // PMIC_LDO4_UV_ERR_INT
+    IRQ_DEF_STD(VMON_LDO_STAT_REG,
+                UV_INT_MASK_REG,
+                LDO4_UV_ERR_SHIFT,
+                LDO4_UV_INT_MASK_SHIFT,
+                UV_INT_CFG1_REG,
+                LDO4_UV_INT_CFG_SHIFT,
+                LDO4_UV_INT_CFG_MASK),
+    // PMIC_LDO4_OV_ERR_INT
+    IRQ_DEF_STD(VMON_LDO_STAT_REG,
+                OV_INT_MASK_REG,
+                LDO4_OV_ERR_SHIFT,
+                LDO4_OV_INT_MASK_SHIFT,
+                OV_INT_CFG1_REG,
+                LDO4_OV_INT_CFG_SHIFT,
+                LDO4_OV_INT_CFG_MASK),
+    // PMIC_PLDO1_UV_ERR_INT
+    IRQ_DEF_STD(VMON_PLDO_STAT_REG,
+                UV_INT_MASK_REG,
+                PLDO1_UV_ERR_SHIFT,
+                PLDO1_UV_INT_MASK_SHIFT,
+                UV_INT_CFG2_REG,
+                PLDO1_UV_INT_CFG_SHIFT,
+                PLDO1_UV_INT_CFG_MASK),
+    // PMIC_PLDO1_OV_ERR_INT
+    IRQ_DEF_STD(VMON_PLDO_STAT_REG,
+                OV_INT_MASK_REG,
+                PLDO1_OV_ERR_SHIFT,
+                PLDO1_OV_INT_MASK_SHIFT,
+                OV_INT_CFG2_REG,
+                PLDO1_OV_INT_CFG_SHIFT,
+                PLDO1_OV_INT_CFG_MASK),
+    // PMIC_PLDO2_UV_ERR_INT
+    IRQ_DEF_STD(VMON_PLDO_STAT_REG,
+                UV_INT_MASK_REG,
+                PLDO2_UV_ERR_SHIFT,
+                PLDO2_UV_INT_MASK_SHIFT,
+                UV_INT_CFG2_REG,
+                PLDO2_UV_INT_CFG_SHIFT,
+                PLDO2_UV_INT_CFG_MASK),
+    // PMIC_PLDO2_OV_ERR_INT
+    IRQ_DEF_STD(VMON_PLDO_STAT_REG,
+                OV_INT_MASK_REG,
+                PLDO2_OV_ERR_SHIFT,
+                PLDO2_OV_INT_MASK_SHIFT,
+                OV_INT_CFG2_REG,
+                PLDO2_OV_INT_CFG_SHIFT,
+                PLDO2_OV_INT_CFG_MASK),
+    // PMIC_EXT_VMON1_UV_ERR_INT
+    IRQ_DEF_STD(EXT_VMON_STAT_REG,
+                UV_INT_MASK_REG,
+                EXT_VMON1_UV_ERR_SHIFT,
+                EXT_VMON1_UV_INT_MASK_SHIFT,
+                UV_INT_CFG2_REG,
+                EXT_VMON1_UV_INT_CFG_SHIFT,
+                EXT_VMON1_UV_INT_CFG_MASK),
+    // PMIC_EXT_VMON1_OV_ERR_INT
+    IRQ_DEF_STD(EXT_VMON_STAT_REG,
+                OV_INT_MASK_REG,
+                EXT_VMON1_OV_ERR_SHIFT,
+                EXT_VMON1_OV_INT_MASK_SHIFT,
+                OV_INT_CFG2_REG,
+                EXT_VMON1_OV_INT_CFG_SHIFT,
+                EXT_VMON1_OV_INT_CFG_MASK),
+    // PMIC_EXT_VMON2_UV_ERR_INT
+    IRQ_DEF_STD(EXT_VMON_STAT_REG,
+                UV_INT_MASK_REG,
+                EXT_VMON2_UV_ERR_SHIFT,
+                EXT_VMON2_UV_INT_MASK_SHIFT,
+                UV_INT_CFG2_REG,
+                EXT_VMON2_UV_INT_CFG_SHIFT,
+                EXT_VMON2_UV_INT_CFG_MASK),
+    // PMIC_EXT_VMON2_OV_ERR_INT
+    IRQ_DEF_STD(EXT_VMON_STAT_REG,
+                OV_INT_MASK_REG,
+                EXT_VMON2_OV_ERR_SHIFT,
+                EXT_VMON2_OV_INT_MASK_SHIFT,
+                OV_INT_CFG2_REG,
+                EXT_VMON2_OV_INT_CFG_SHIFT,
+                EXT_VMON2_OV_INT_CFG_MASK),
+    // PMIC_LDO1_ILIM_ERR_INT
+    IRQ_DEF_NMI_CFG(ILIM_STAT_REG,
+                    LDO1_ILIM_ERR_SHIFT,
+                    ILIM_CFG_REG,
+                    LDO1_ILIM_CFG_SHIFT,
+                    LDO1_ILIM_CFG_MASK),
+    // PMIC_LDO2_ILIM_ERR_INT
+    IRQ_DEF_NMI_CFG(ILIM_STAT_REG,
+                    LDO2_ILIM_ERR_SHIFT,
+                    ILIM_CFG_REG,
+                    LDO2_ILIM_CFG_SHIFT,
+                    LDO2_ILIM_CFG_MASK),
+    // PMIC_LDO3_ILIM_ERR_INT
+    IRQ_DEF_NMI_CFG(ILIM_STAT_REG,
+                    LDO3_ILIM_ERR_SHIFT,
+                    ILIM_CFG_REG,
+                    LDO3_ILIM_CFG_SHIFT,
+                    LDO3_ILIM_CFG_MASK),
+    // PMIC_LDO4_ILIM_ERR_INT
+    IRQ_DEF_NMI_CFG(ILIM_STAT_REG,
+                    LDO4_ILIM_ERR_SHIFT,
+                    ILIM_CFG_REG,
+                    LDO4_ILIM_CFG_SHIFT,
+                    LDO4_ILIM_CFG_MASK),
+    // PMIC_PLDO1_ILIM_ERR_INT
+    IRQ_DEF_NMI_CFG(ILIM_STAT_REG,
+                    PLDO1_ILIM_ERR_SHIFT,
+                    ILIM_CFG_REG,
+                    PLDO1_ILIM_CFG_SHIFT,
+                    PLDO1_ILIM_CFG_MASK),
+    // PMIC_PLDO2_ILIM_ERR_INT
+    IRQ_DEF_NMI_CFG(ILIM_STAT_REG,
+                    PLDO2_ILIM_ERR_SHIFT,
+                    ILIM_CFG_REG,
+                    PLDO2_ILIM_CFG_SHIFT,
+                    PLDO2_ILIM_CFG_MASK),
+    // PMIC_BB_AVG_ILIM_ERR_INT
+    IRQ_DEF_NMI_NCFG(ILIM_STAT_REG, BB_AVG_ILIM_ERR_SHIFT),
+    // PMIC_ABIST_ERR_INT
+    IRQ_DEF_NMI_NCFG(BIST_STAT_REG, ABIST_ERR_SHIFT),
+    // PMIC_LBIST_ERR_INT
+    IRQ_DEF_NMI_NCFG(BIST_STAT_REG, LBIST_ERR_SHIFT),
+    // PMIC_TMR_REG_ERR_INT
+    IRQ_DEF_NMI_NCFG(BIST_STAT_REG, TMR_REG_ERR_SHIFT),
+    // PMIC_M_PMIC_HB_ERR_INT
+    IRQ_DEF_NMI_NCFG(BIST_STAT_REG, M_PMIC_HB_ERR_SHIFT),
+    // PMIC_SAFE_ST_TMO_RST_ERR_INT
+    IRQ_DEF_NMI_NCFG(DEV_ERR_STAT_REG, SAFE_ST_TMO_RST_ERR_SHIFT),
+    // PMIC_SPI_CRC_ERR_INT
+    IRQ_DEF_NMI_NCFG(SPI_ERR_STAT_REG, SPI_CRC_ERR_SHIFT),
+    // PMIC_FRM_ERR_INT
+    IRQ_DEF_NMI_NCFG(SPI_ERR_STAT_REG, FRM_ERR_SHIFT),
+    // PMIC_ADDR_ERR_INT
+    IRQ_DEF_NMI_NCFG(SPI_ERR_STAT_REG, ADDR_ERR_SHIFT),
+    // PMIC_SCLK_ERR_INT
+    IRQ_DEF_NMI_NCFG(SPI_ERR_STAT_REG, SCLK_ERR_SHIFT),
+    // PMIC_COMP1_ERR_INT
+    IRQ_DEF_NMI_NCFG(CM_STAT1_REG, COMP1_ERR_SHIFT),
+    // PMIC_COMP1P_UV_ERR_INT
+    IRQ_DEF_STD(CM_STAT1_REG,
+                CM_VMON_INT_MASK_CFG_REG,
+                COMP1P_UV_ERR_SHIFT,
+                COMP1P_UV_INT_MASK_SHIFT,
+                CM_VMON_INT_CFG_REG,
+                COMP1P_UV_INT_CFG_SHIFT,
+                COMP1P_UV_INT_CFG_MASK),
+    // PMIC_COMP1P_OV_ERR_INT
+    IRQ_DEF_STD(CM_STAT1_REG,
+                CM_VMON_INT_MASK_CFG_REG,
+                COMP1P_OV_ERR_SHIFT,
+                COMP1P_OV_INT_MASK_SHIFT,
+                CM_VMON_INT_CFG_REG,
+                COMP1P_OV_INT_CFG_SHIFT,
+                COMP1P_OV_INT_CFG_MASK),
+    // PMIC_COMP1N_UV_ERR_INT
+    IRQ_DEF_STD(CM_STAT1_REG,
+                CM_VMON_INT_MASK_CFG_REG,
+                COMP1N_UV_ERR_SHIFT,
+                COMP1N_UV_INT_MASK_SHIFT,
+                CM_VMON_INT_CFG_REG,
+                COMP1N_UV_INT_CFG_SHIFT,
+                COMP1N_UV_INT_CFG_MASK),
+    // PMIC_COMP1N_OV_ERR_INT
+    IRQ_DEF_STD(CM_STAT1_REG,
+                CM_VMON_INT_MASK_CFG_REG,
+                COMP1N_OV_ERR_SHIFT,
+                COMP1N_OV_INT_MASK_SHIFT,
+                CM_VMON_INT_CFG_REG,
+                COMP1N_OV_INT_CFG_SHIFT,
+                COMP1N_OV_INT_CFG_MASK),
+    // PMIC_COMP2_ERR_INT
+    IRQ_DEF_NMI_NCFG(CM_STAT2_REG, COMP2_ERR_SHIFT),
+    // PMIC_COMP2P_UV_ERR_INT
+    IRQ_DEF_STD(CM_STAT2_REG,
+                CM_VMON_INT_MASK_CFG_REG,
+                COMP2P_UV_ERR_SHIFT,
+                COMP2P_UV_INT_MASK_SHIFT,
+                CM_VMON_INT_CFG_REG,
+                COMP2P_UV_INT_CFG_SHIFT,
+                COMP2P_UV_INT_CFG_MASK),
+    // PMIC_COMP2P_OV_ERR_INT
+    IRQ_DEF_STD(CM_STAT2_REG,
+                CM_VMON_INT_MASK_CFG_REG,
+                COMP2P_OV_ERR_SHIFT,
+                COMP2P_OV_INT_MASK_SHIFT,
+                CM_VMON_INT_CFG_REG,
+                COMP2P_OV_INT_CFG_SHIFT,
+                COMP2P_OV_INT_CFG_MASK),
+    // PMIC_COMP2N_UV_ERR_INT
+    IRQ_DEF_STD(CM_STAT2_REG,
+                CM_VMON_INT_MASK_CFG_REG,
+                COMP2N_UV_ERR_SHIFT,
+                COMP2N_UV_INT_MASK_SHIFT,
+                CM_VMON_INT_CFG_REG,
+                COMP2N_UV_INT_CFG_SHIFT,
+                COMP2N_UV_INT_CFG_MASK),
+    // PMIC_COMP2N_OV_ERR_INT
+    IRQ_DEF_STD(CM_STAT2_REG,
+                CM_VMON_INT_MASK_CFG_REG,
+                COMP2N_OV_ERR_SHIFT,
+                COMP2N_OV_INT_MASK_SHIFT,
+                CM_VMON_INT_CFG_REG,
+                COMP2N_OV_INT_CFG_SHIFT,
+                COMP2N_OV_INT_CFG_MASK),
+};
+
+static const uint16_t IrqStatusRegisters[NUM_STAT_REGISTERS] = {
+    REG_STAT_REG,
+    RDBK_ERR_STAT_REG,
+    OFF_STATE_STAT1_REG,
+    OFF_STATE_STAT2_REG,
+    WD_ERR_STAT_REG,
+    ESM_ERR_STAT_REG,
+    DCDC_STAT_REG,
+    VMON_LDO_STAT_REG,
+    VMON_PLDO_STAT_REG,
+    EXT_VMON_STAT_REG,
+    ILIM_STAT_REG,
+    BIST_STAT_REG,
+    DEV_ERR_STAT_REG,
+    SPI_ERR_STAT_REG,
+    CM_STAT1_REG,
+    CM_STAT2_REG,
+};
+
+static const uint16_t IrqMaskRegisters[] = {
+    RDBK_INT_MASK_CFG_REG,
+    WD_INT_CFG_REG,
+    UV_DCDC_CFG_REG,
+    OV_DCDC_CFG_REG,
+    UV_INT_MASK_REG,
+    OV_INT_MASK_REG,
+    CM_VMON_INT_MASK_CFG_REG,
+};
+
+static const uint16_t IrqConfRegisters[] = {
+    RDBK_INT_CFG1_REG,
+    RDBK_INT_CFG2_REG,
+    SAFETY_CFG_REG,
+    WD_INT_CFG_REG,
+    ESM_INT_CFG_REG,
+    UV_DCDC_CFG_REG,
+    OV_DCDC_CFG_REG,
+    UV_INT_CFG1_REG,
+    OV_INT_CFG1_REG,
+    UV_INT_CFG2_REG,
+    OV_INT_CFG2_REG,
+    ILIM_CFG_REG,
+    CM_VMON_INT_CFG_REG,
+};
+
+/* ========================================================================== */
+/*                          Function Definitions                              */
+/* ========================================================================== */
+static inline void IRQ_setIntrStat(Pmic_IrqStat_t *irqStat, uint32_t irqNum)
+{
+    const uint32_t mask = ((uint32_t)1U << (irqNum % PMIC_NUM_BITS_IN_INTR_STAT));
+
+    if (irqNum <= PMIC_IRQ_MAX)
+    {
+        // IRQs 0 to 31 go to index 0, IRQs 32 to 63 go to index 1.
+        // At an index, the IRQ is stored at its corresponding bit
+        // (e.g., IRQ 49's status will be stored at bit 17 at index 1)
+        irqStat->intStat[irqNum / PMIC_NUM_BITS_IN_INTR_STAT] |= mask;
+    }
+}
+
+static inline void IRQ_clrIntrStat(Pmic_IrqStat_t *irqStat, uint32_t irqNum)
+{
+    const uint32_t mask = ((uint32_t)1U << (irqNum % PMIC_NUM_BITS_IN_INTR_STAT));
+
+    if (irqNum <= PMIC_IRQ_MAX)
+    {
+        irqStat->intStat[irqNum / PMIC_NUM_BITS_IN_INTR_STAT] &= ~mask;
+    }
+}
+
+static uint8_t IRQ_getNextFlag(Pmic_IrqStat_t *irqStat) {
+    uint8_t index = 0U, bitPos = 0U;
+    bool foundFlag = false;
+
+    // For each element in struct member intStat of irqStat...
+    for (index = 0U; index < PMIC_NUM_ELEM_IN_INTR_STAT; index++) {
+        // If current element has no IRQ statuses set, move onto next element
+        if (irqStat->intStat[index] == 0U) {
+            continue;
+        }
+
+        // For each bit in the element...
+        for (bitPos = 0U; bitPos < PMIC_NUM_BITS_IN_INTR_STAT; bitPos++) {
+            // If the bit is set...
+            if ((irqStat->intStat[index] & (1U << bitPos)) != 0U) {
+                // Clear bit in intrStat element and exit loop
+                irqStat->intStat[index] &= ~(1U << bitPos);
+                foundFlag = true;
+                break;
+            }
+        }
+
+        if (foundFlag) {
+            break;
+        }
+    }
+
+    // Return the corresponding IRQ number
+    return (bitPos + (PMIC_NUM_BITS_IN_INTR_STAT * index));
+}
+
+static int32_t IRQ_setMask(Pmic_CoreHandle_t *handle, uint8_t irqNum, bool shouldMask) {
+    int32_t status = PMIC_ST_SUCCESS;
+    uint8_t regData = 0U;
+    uint16_t maskReg = 0U;
+    uint8_t maskShift = 0U;
+
+    // Check for invalid IRQ number
+    if (irqNum > PMIC_IRQ_MAX) {
+        status = PMIC_ST_ERR_INV_PARAM;
+    } else {
+        maskReg = IRQ[irqNum].maskReg;
+        maskShift = IRQ[irqNum].maskShift;
+    }
+
+    // Check whether IRQ is maskable
+    if ((status == PMIC_ST_SUCCESS) && (maskReg == PMIC_IRQ_INVALID_REG)) {
+        status = PMIC_ST_ERR_NOT_SUPPORTED;
+    }
+
+    // Read IRQ mask register
+    if (status == PMIC_ST_SUCCESS) {
+        Pmic_criticalSectionStart(handle);
+        status = Pmic_ioRxByte(handle, maskReg, &regData);
+        Pmic_criticalSectionStop(handle);
+    }
+
+    if (status == PMIC_ST_SUCCESS) {
+        // Modify IRQ mask bit field
+        Pmic_setBitField_b(&regData, maskShift, shouldMask);
+
+        // Write new register value back to PMIC
+        Pmic_criticalSectionStart(handle);
+        status = Pmic_ioTxByte(handle, maskReg, regData);
+        Pmic_criticalSectionStop(handle);
+    }
+
+    return status;
+}
+
+static int32_t IRQ_setConfig(Pmic_CoreHandle_t *handle, uint8_t irqNum, uint8_t config) {
+    int32_t status = PMIC_ST_SUCCESS;
+    uint8_t regData = 0U;
+    uint16_t configReg = 0U;
+    uint8_t configShift = 0U;
+    uint8_t configMask = 0U;
+
+    // Check for invalid IRQ number
+    if (irqNum > PMIC_IRQ_MAX) {
+        status = PMIC_ST_ERR_INV_PARAM;
+    } else {
+        configReg = IRQ[irqNum].confReg;
+        configShift = IRQ[irqNum].confShift;
+        configMask = IRQ[irqNum].confMask;
+    }
+
+    // Check whether IRQ is configurable
+    if ((status == PMIC_ST_SUCCESS) && (configReg == PMIC_IRQ_INVALID_REG)) {
+        status = PMIC_ST_ERR_NOT_SUPPORTED;
+    }
+
+    // Read IRQ configuration register
+    if (status == PMIC_ST_SUCCESS) {
+        Pmic_criticalSectionStart(handle);
+        status = Pmic_ioRxByte(handle, configReg, &regData);
+        Pmic_criticalSectionStop(handle);
+    }
+
+    if (status == PMIC_ST_SUCCESS) {
+        // Modify IRQ config bit field
+        Pmic_setBitField(&regData, configShift, configMask, config);
+
+        // Write new register value back to PMIC
+        Pmic_criticalSectionStart(handle);
+        status = Pmic_ioTxByte(handle, configReg, regData);
+        Pmic_criticalSectionStop(handle);
+    }
+
+    return status;
+}
+
+int32_t Pmic_irqSetCfg(Pmic_CoreHandle_t *handle, const Pmic_IrqCfg_t *irqCfg) {
+    int32_t status = Pmic_checkPmicCoreHandle(handle);
+
+    // Parameter validation
+    if ((status == PMIC_ST_SUCCESS) && (irqCfg == NULL)) {
+        status = PMIC_ST_ERR_NULL_PARAM;
+    }
+
+    if ((status == PMIC_ST_SUCCESS) && (irqCfg->irqNum > PMIC_IRQ_MAX)) {
+       status = PMIC_ST_ERR_INV_PARAM;
+    }
+
+    // Set IRQ mask if requested
+    if (Pmic_validParamStatusCheck(irqCfg->validParams, PMIC_IRQ_CFG_MASK_VALID, status)) {
+        status = IRQ_setMask(handle, irqCfg->irqNum, irqCfg->mask);
+    }
+
+    // Set IRQ config if requested
+    if (Pmic_validParamStatusCheck(irqCfg->validParams, PMIC_IRQ_CFG_CONFIG_VALID_SHIFT, status)) {
+        status = IRQ_setConfig(handle, irqCfg->irqNum, irqCfg->config);
+    }
+
+    return status;
+}
+
+static inline bool IRQ_anyMasksForReg(uint8_t numCfgs, const Pmic_IrqCfg_t *cfgs, uint16_t regAddr) {
+    bool anyRegs = false;
+
+    for (uint8_t i = 0U; (i < numCfgs) && !anyRegs; i++) {
+        const uint8_t irqNum = cfgs[i].irqNum;
+        anyRegs = (IRQ[irqNum].maskReg == regAddr);
+    }
+
+    return anyRegs;
+}
+
+static inline bool IRQ_anyConfigsForReg(uint8_t numCfgs, const Pmic_IrqCfg_t *cfgs, uint16_t regAddr) {
+    bool anyRegs = false;
+
+    for (uint8_t i = 0U; (i < numCfgs) && !anyRegs; i++) {
+        const uint8_t irqNum = cfgs[i].irqNum;
+        anyRegs = (IRQ[irqNum].confReg == regAddr);
+    }
+
+    return anyRegs;
+}
+
+static int32_t IRQ_handleRecordsForRegMask(Pmic_CoreHandle_t *handle,
+                                           uint8_t numCfgs,
+                                           const Pmic_IrqCfg_t *cfgs,
+                                           uint16_t regAddr,
+                                           uint8_t *processedCfgs) {
+    int32_t status = PMIC_ST_SUCCESS;
+    uint8_t regData = 0U;
+    const bool anyMasks = IRQ_anyMasksForReg(numCfgs, cfgs, regAddr);
+
+    if (anyMasks) {
+        // Get the current value of this IRQ mask register
+        Pmic_criticalSectionStart(handle);
+        status = Pmic_ioRxByte(handle, regAddr, &regData);
+        Pmic_criticalSectionStop(handle);
+    }
+
+    if ((status == PMIC_ST_SUCCESS) && anyMasks) {
+        for (uint8_t i = 0U; i < numCfgs; i++) {
+            const uint8_t irqNum = cfgs[i].irqNum;
+            const uint8_t userMask = (uint8_t)(1U << IRQ[irqNum].maskShift);
+
+            // If the current mask setting isn't targeted at the register we are
+            // currently building, skip it
+            if (regAddr != IRQ[irqNum].maskReg) {
+                continue;
+            }
+
+            // If the user didn't set the mask validParam for this config, skip it
+            if (Pmic_validParamCheck(cfgs->validParams, PMIC_IRQ_CFG_MASK_VALID) == false) {
+                continue;
+            }
+
+            if (cfgs[i].mask) {
+                regData |= userMask;
+            } else {
+                regData &= ~userMask;
+            }
+
+            // Increment the counter indicating we processed this record
+            *processedCfgs += 1;
+        }
+    }
+
+    // If status is still good and we did find records that apply to this
+    // register, write the new value of this register back to the device
+    if ((status == PMIC_ST_SUCCESS) && *processedCfgs > 0) {
+        Pmic_criticalSectionStart(handle);
+        status = Pmic_ioTxByte(handle, regAddr, regData);
+        Pmic_criticalSectionStop(handle);
+    }
+
+    return status;
+}
+
+static int32_t IRQ_handleRecordsForRegConfig(Pmic_CoreHandle_t *handle,
+                                             uint8_t numCfgs,
+                                             const Pmic_IrqCfg_t *cfgs,
+                                             uint16_t regAddr,
+                                             uint8_t *processedCfgs) {
+    int32_t status = PMIC_ST_SUCCESS;
+    uint8_t regData = 0U;
+    const bool anyConfigs = IRQ_anyConfigsForReg(numCfgs, cfgs, regAddr);
+
+    if (anyConfigs) {
+        // Get the current value of this IRQ mask register
+        Pmic_criticalSectionStart(handle);
+        status = Pmic_ioRxByte(handle, regAddr, &regData);
+        Pmic_criticalSectionStop(handle);
+    }
+
+    if ((status == PMIC_ST_SUCCESS) && anyConfigs) {
+        for (uint8_t i = 0U; i < numCfgs; i++) {
+            const uint8_t irqNum = cfgs[i].irqNum;
+            const uint8_t userMask = (uint8_t)((cfgs[i].config << IRQ[irqNum].confShift) & IRQ[irqNum].confMask);
+
+            // If the current mask setting isn't targeted at the register we are
+            // currently building, skip it
+            if (regAddr != IRQ[irqNum].confReg) {
+                continue;
+            }
+
+            // If the user didn't set the config validParam for this config, skip it
+            if (Pmic_validParamCheck(cfgs->validParams, PMIC_IRQ_CFG_CONFIG_VALID) == false) {
+                continue;
+            }
+
+            regData &= ~IRQ[irqNum].confMask;
+            regData |= userMask;
+
+            // Increment the counter indicating we processed this record
+            *processedCfgs += 1;
+        }
+    }
+
+    // If status is still good and we did find records that apply to this
+    // register, write the new value of this register back to the device
+    if ((status == PMIC_ST_SUCCESS) && *processedCfgs > 0) {
+        Pmic_criticalSectionStart(handle);
+        status = Pmic_ioTxByte(handle, regAddr, regData);
+        Pmic_criticalSectionStop(handle);
+    }
+
+    return status;
+}
+
+int32_t Pmic_irqSetCfgs(Pmic_CoreHandle_t *handle, uint8_t numIrqs, const Pmic_IrqCfg_t *irqCfgs) {
+    int32_t status = Pmic_checkPmicCoreHandle(handle);
+    uint8_t lastProcessed = 0U, totalProcessed = 0U;
+
+    // Parameter validation
+    if ((status == PMIC_ST_SUCCESS) && (irqCfgs == NULL)) {
+        status = PMIC_ST_ERR_NULL_PARAM;
+    }
+
+    if ((status == PMIC_ST_SUCCESS) && (numIrqs > PMIC_IRQ_NUM)) {
+        status = PMIC_ST_ERR_INV_PARAM;
+    }
+
+    // Handle mask controls
+    for (uint8_t regIndex = 0U; regIndex < NUM_MASK_REGISTERS; regIndex++) {
+        // If status is no longer good or all user requested masks have been
+        // processed, we can stop iterating
+        if ((status != PMIC_ST_SUCCESS) || (totalProcessed >= numIrqs)) {
+            break;
+        }
+
+        if (status == PMIC_ST_SUCCESS) {
+            status = IRQ_handleRecordsForRegMask(handle, numIrqs, irqCfgs, IrqMaskRegisters[regIndex], &lastProcessed);
+            totalProcessed += lastProcessed;
+        }
+    }
+
+    // Reset tracking variables
+    lastProcessed = 0U;
+    totalProcessed = 0U;
+
+    // Handle config controls
+    for (uint8_t regIndex = 0U; regIndex < NUM_CONF_REGISTERS; regIndex++) {
+        // If status is no longer good or all user requested masks have been
+        // processed, we can stop iterating
+        if ((status != PMIC_ST_SUCCESS) || (totalProcessed >= numIrqs)) {
+            break;
+        }
+
+        if (status == PMIC_ST_SUCCESS) {
+            status = IRQ_handleRecordsForRegConfig(handle, numIrqs, irqCfgs, IrqConfRegisters[regIndex], &lastProcessed);
+            totalProcessed += lastProcessed;
+        }
+    }
+
+    return status;
+}
+
+static int32_t IRQ_getMask(Pmic_CoreHandle_t *handle, Pmic_IrqCfg_t *irqCfg) {
+    int32_t status = PMIC_ST_SUCCESS;
+    uint8_t regData = 0U;
+    uint16_t irqMaskReg = 0U;
+    uint8_t irqMaskShift = 0U;
+    const uint8_t irqNum = irqCfg->irqNum;
+
+    // NOTE: This function does not validate param for whether mask was
+    // requested or not, that is handled in the higher level function that calls
+    // this one.
+
+    // Check for invalid IRQ number
+    if (irqNum > PMIC_IRQ_MAX) {
+        status = PMIC_ST_ERR_INV_PARAM;
+    } else {
+        irqMaskReg = IRQ[irqNum].maskReg;
+        irqMaskShift = IRQ[irqNum].maskShift;
+    }
+
+    // Check whether IRQ is maskable
+    if ((status == PMIC_ST_SUCCESS) &&
+        (irqMaskReg == PMIC_IRQ_INVALID_REG)) {
+        status = PMIC_ST_ERR_NOT_SUPPORTED;
+    }
+
+    // Read IRQ mask register
+    if (status == PMIC_ST_SUCCESS) {
+        Pmic_criticalSectionStart(handle);
+        status = Pmic_ioRxByte(handle, irqMaskReg, &regData);
+        Pmic_criticalSectionStop(handle);
+    }
+
+    if (status == PMIC_ST_SUCCESS) {
+        // Extract IRQ mask bit field
+        irqCfg->mask = Pmic_getBitField_b(regData, irqMaskShift);
+    }
+
+    return status;
+}
+
+static int32_t IRQ_getConfig(Pmic_CoreHandle_t *handle, Pmic_IrqCfg_t *irqCfg) {
+    int32_t status = PMIC_ST_SUCCESS;
+    uint8_t regData = 0U;
+    uint16_t irqConfigReg = 0U;
+    uint8_t irqConfigShift = 0U;
+    uint8_t irqConfigMask = 0U;
+    const uint8_t irqNum = irqCfg->irqNum;
+
+    // NOTE: This function does not validate param for whether config was
+    // requested or not, that is handled in the higher level function that calls
+    // this one.
+
+    // Check for invalid IRQ number
+    if (irqNum > PMIC_IRQ_MAX) {
+        status = PMIC_ST_ERR_INV_PARAM;
+    } else {
+        irqConfigReg = IRQ[irqNum].confReg;
+        irqConfigShift = IRQ[irqNum].confShift;
+        irqConfigMask = IRQ[irqNum].confMask;
+    }
+
+    // Check whether IRQ is maskable
+    if ((status == PMIC_ST_SUCCESS) &&
+        (irqConfigReg == PMIC_IRQ_INVALID_REG)) {
+        status = PMIC_ST_ERR_NOT_SUPPORTED;
+    }
+
+    // Read IRQ mask register
+    if (status == PMIC_ST_SUCCESS) {
+        Pmic_criticalSectionStart(handle);
+        status = Pmic_ioRxByte(handle, irqConfigReg, &regData);
+        Pmic_criticalSectionStop(handle);
+    }
+
+    if (status == PMIC_ST_SUCCESS) {
+        // Extract IRQ config bit field
+        irqCfg->config = Pmic_getBitField(regData, irqConfigShift, irqConfigMask);
+    }
+
+    return status;
+}
+
+static inline int32_t IRQ_getCfg(Pmic_CoreHandle_t *handle, Pmic_IrqCfg_t *irqCfg) {
+    int32_t status = PMIC_ST_SUCCESS;
+
+    if (Pmic_validParamCheck(irqCfg->validParams, PMIC_IRQ_CFG_MASK_VALID)) {
+        status = IRQ_getMask(handle, irqCfg);
+    }
+
+    if (Pmic_validParamStatusCheck(irqCfg->validParams, PMIC_IRQ_CFG_CONFIG_VALID, status)) {
+        status = IRQ_getConfig(handle, irqCfg);
+    }
+
+    return status;
+}
+
+int32_t Pmic_irqGetCfg(Pmic_CoreHandle_t *handle, Pmic_IrqCfg_t *irqCfg) {
+    int32_t status = Pmic_checkPmicCoreHandle(handle);
+
+    if ((status == PMIC_ST_SUCCESS) && (irqCfg == NULL)) {
+        status = PMIC_ST_ERR_NULL_PARAM;
+    }
+
+    if (status == PMIC_ST_SUCCESS) {
+        status = IRQ_getCfg(handle, irqCfg);
+    }
+
+    return status;
+}
+
+int32_t Pmic_irqGetCfgs(Pmic_CoreHandle_t *handle, uint8_t numIrqs, Pmic_IrqCfg_t *irqCfgs) {
+    int32_t status = Pmic_checkPmicCoreHandle(handle);
+
+    if ((status == PMIC_ST_SUCCESS) && (irqCfgs == NULL)) {
+        status = PMIC_ST_ERR_NULL_PARAM;
+    }
+
+    if ((status == PMIC_ST_SUCCESS) && (numIrqs > PMIC_IRQ_NUM)) {
+        status = PMIC_ST_ERR_INV_PARAM;
+    }
+
+    for (uint8_t i = 0U; ((status == PMIC_ST_SUCCESS) && (i < numIrqs)); i++) {
+        status = IRQ_getCfg(handle, &irqCfgs[i]);
+    }
+
+    return status;
+}
+
+static int32_t IRQ_getIrqStatForReg(Pmic_CoreHandle_t *handle, Pmic_IrqStat_t *irqStat, uint16_t regAddr) {
+    int32_t status = PMIC_ST_SUCCESS;
+    uint8_t regData = 0U;
+
+    // Read from the status register
+    Pmic_criticalSectionStart(handle);
+    status = Pmic_ioRxByte(handle, regAddr, &regData);
+    Pmic_criticalSectionStop(handle);
+
+    if (status == PMIC_ST_SUCCESS) {
+        for (uint8_t i = 0U; i < COUNT(IRQ); i++) {
+            // If the register for this IRQ isn't the one we just read, skip it
+            if (IRQ[i].statReg != regAddr) {
+                continue;
+            }
+
+            // If the status bit is set for this IRQ, indicate that in irqStat,
+            // otherwise clear the bit in irqStat
+            if (Pmic_getBitField_b(regData, IRQ[i].statShift)) {
+                IRQ_setIntrStat(irqStat, i);
+            } else {
+                IRQ_clrIntrStat(irqStat, i);
+            }
+        }
+    }
+
+    return status;
+}
+
+int32_t Pmic_irqGetStat(Pmic_CoreHandle_t *handle, Pmic_IrqStat_t *irqStat) {
+    int32_t status = Pmic_checkPmicCoreHandle(handle);
+
+    if ((status == PMIC_ST_SUCCESS) && (irqStat == NULL)) {
+        status = PMIC_ST_ERR_NULL_PARAM;
+    }
+
+    for (uint8_t i = 0U; i < NUM_STAT_REGISTERS; i++) {
+        if (status != PMIC_ST_SUCCESS) {
+            break;
+        }
+
+        status = IRQ_getIrqStatForReg(handle, irqStat, IrqStatusRegisters[i]);
+    }
+
+    return status;
+}
+
+int32_t Pmic_irqGetNextFlag(Pmic_IrqStat_t *irqStat, uint8_t *irqNum) {
+    int32_t status = PMIC_ST_SUCCESS;
+    const bool irqStatEmpty = (
+        (irqStat->intStat[0] == 0) &&
+        (irqStat->intStat[1] == 0) &&
+        (irqStat->intStat[2] == 0) &&
+        (irqStat->intStat[3] == 0));
+
+    if ((status == PMIC_ST_SUCCESS) &&
+        ((irqStat == NULL) || (irqNum == NULL))) {
+        status = PMIC_ST_ERR_NULL_PARAM;
+    }
+
+    if ((status == PMIC_ST_SUCCESS) && irqStatEmpty) {
+        status = PMIC_ST_WARN_NO_IRQ_REMAINING;
+    }
+
+    if (status == PMIC_ST_SUCCESS) {
+        *irqNum = IRQ_getNextFlag(irqStat);
+    }
+
+    return status;
+}
+
+int32_t Pmic_irqGetFlag(Pmic_CoreHandle_t *handle, uint8_t irqNum, bool *flag) {
+    int32_t status = Pmic_checkPmicCoreHandle(handle);
+    uint8_t regData = 0U;
+
+    if ((status == PMIC_ST_SUCCESS) && (irqNum > PMIC_IRQ_MAX)) {
+        status = PMIC_ST_ERR_INV_PARAM;
+    }
+
+    if ((status == PMIC_ST_SUCCESS) && (flag == NULL)) {
+        status = PMIC_ST_ERR_NULL_PARAM;
+    }
+
+    // Read IRQ status register
+    if (status == PMIC_ST_SUCCESS) {
+        Pmic_criticalSectionStart(handle);
+        status = Pmic_ioRxByte(handle, IRQ[irqNum].statReg, &regData);
+        Pmic_criticalSectionStop(handle);
+    }
+
+    // Extract IRQ status
+    if (status == PMIC_ST_SUCCESS) {
+        *flag = Pmic_getBitField_b(regData, IRQ[irqNum].statShift);
+    }
+
+    return status;
+}
+
+int32_t Pmic_irqClrFlag(Pmic_CoreHandle_t *handle, uint8_t irqNum) {
+    int32_t status = Pmic_checkPmicCoreHandle(handle);
+    uint8_t regData = 0U;
+    uint8_t shift = 0U;
+    uint16_t reg = 0U;
+
+    if ((status == PMIC_ST_SUCCESS) && (irqNum > PMIC_IRQ_MAX)) {
+        status = PMIC_ST_ERR_INV_PARAM;
+    }
+
+    shift = IRQ[irqNum].statShift;
+    reg = IRQ[irqNum].statReg;
+
+    // handle special case of OFF_STATE_STAT{1,2}_REG which cannot be cleared
+    // with W1/C, but instead has a dedicated register with a single bit which
+    // clears all bits in these two registers
+    if ((status == PMIC_ST_SUCCESS) &&
+        ((reg == OFF_STATE_STAT1_REG) || (reg == OFF_STATE_STAT2_REG))) {
+        reg = OFF_STATE_CLR_REG;
+        shift = OFF_STATE_STAT_CLR_SHIFT;
+    }
+
+    if (status == PMIC_ST_SUCCESS) {
+        // IRQ statuses are W1C - write 1 to clear
+        Pmic_setBitField_b(&regData, shift, PMIC_ENABLE);
+
+        // Write data to PMIC
+        Pmic_criticalSectionStart(handle);
+        status = Pmic_ioTxByte(handle, reg, regData);
+        Pmic_criticalSectionStop(handle);
+    }
+
+    return status;
+}
+
+int32_t Pmic_irqClrAllFlags(Pmic_CoreHandle_t *handle) {
+    int32_t status = Pmic_checkPmicCoreHandle(handle);
+    uint16_t reg = 0U;
+
+    // All IRQ statuses are W1C, writing to reserved bits has no effect, so just
+    // write every bit to 1
+    Pmic_criticalSectionStart(handle);
+    for (uint8_t i = 0; ((i < NUM_STAT_REGISTERS) && (status == PMIC_ST_SUCCESS)); i++) {
+        reg = IrqStatusRegisters[i];
+
+        // OFF_STATE_STAT{1,2}_REG are special case, and will be handled
+        // separately
+        if ((reg == OFF_STATE_STAT1_REG) || (reg == OFF_STATE_STAT2_REG)) {
+            continue;
+        }
+
+        if (status == PMIC_ST_SUCCESS) {
+            status = Pmic_ioTxByte(handle, reg, 0xFFU);
+        }
+    }
+
+    // Clear OFF_STATE_STAT{1,2}_REG
+    if (status == PMIC_ST_SUCCESS) {
+        status = Pmic_ioTxByte(handle, OFF_STATE_CLR_REG, 1U << OFF_STATE_STAT_CLR_SHIFT);
+    }
+
+    Pmic_criticalSectionStop(handle);
+
+    return status;
+}

--- a/src/pmic_wdg.c
+++ b/src/pmic_wdg.c
@@ -469,7 +469,7 @@ int32_t Pmic_wdgSetEnableState(Pmic_CoreHandle_t *handle, bool enable) {
     }
 
     if (status == PMIC_ST_SUCCESS) {
-        Pmic_setBitField_b(&regVal, PMIC_WD_EN_SHIFT, PMIC_WD_EN_MASK, enable);
+        Pmic_setBitField_b(&regVal, PMIC_WD_EN_SHIFT, enable);
         status = Pmic_ioTxByte(handle, PMIC_WD_TH_CFG_REG, regVal);
     }
 
@@ -494,7 +494,7 @@ int32_t Pmic_wdgGetEnableState(Pmic_CoreHandle_t *handle, bool *isEnabled) {
     }
 
     if (status == PMIC_ST_SUCCESS) {
-        *isEnabled = Pmic_getBitField_b(regData, PMIC_WD_EN_SHIFT, PMIC_WD_EN_MASK);
+        *isEnabled = Pmic_getBitField_b(regData, PMIC_WD_EN_SHIFT);
     }
 
     Pmic_criticalSectionStop(handle);
@@ -612,7 +612,7 @@ int32_t Pmic_wdgSetPowerHold(Pmic_CoreHandle_t *handle, bool enable) {
     }
 
     if (status == PMIC_ST_SUCCESS) {
-        Pmic_setBitField_b(&regVal, PMIC_WD_PWRHOLD_SHIFT, PMIC_WD_PWRHOLD_MASK, enable);
+        Pmic_setBitField_b(&regVal, PMIC_WD_PWRHOLD_SHIFT, enable);
         status = Pmic_ioTxByte(handle, PMIC_WD_CFG_REG, regVal);
     }
 
@@ -637,7 +637,7 @@ int32_t Pmic_wdgGetPowerHold(Pmic_CoreHandle_t *handle, bool *isEnabled) {
     }
 
     if (status == PMIC_ST_SUCCESS) {
-        *isEnabled = Pmic_getBitField_b(regData, PMIC_WD_PWRHOLD_SHIFT, PMIC_WD_PWRHOLD_MASK);
+        *isEnabled = Pmic_getBitField_b(regData, PMIC_WD_PWRHOLD_SHIFT);
     }
 
     Pmic_criticalSectionStop(handle);
@@ -656,7 +656,7 @@ int32_t Pmic_wdgSetReturnToLongWindow(Pmic_CoreHandle_t *handle, bool enable) {
     }
 
     if (status == PMIC_ST_SUCCESS) {
-        Pmic_setBitField_b(&regVal, PMIC_WD_RETURN_LONGWIN_SHIFT, PMIC_WD_RETURN_LONGWIN_MASK, enable);
+        Pmic_setBitField_b(&regVal, PMIC_WD_RETURN_LONGWIN_SHIFT, enable);
         status = Pmic_ioTxByte(handle, PMIC_WD_CFG_REG, regVal);
     }
 
@@ -681,7 +681,7 @@ int32_t Pmic_wdgGetReturnToLongWindow(Pmic_CoreHandle_t *handle, bool *isEnabled
     }
 
     if (status == PMIC_ST_SUCCESS) {
-        *isEnabled = Pmic_getBitField_b(regData, PMIC_WD_RETURN_LONGWIN_SHIFT, PMIC_WD_RETURN_LONGWIN_MASK);
+        *isEnabled = Pmic_getBitField_b(regData, PMIC_WD_RETURN_LONGWIN_SHIFT);
     }
 
     return status;
@@ -705,51 +705,35 @@ int32_t Pmic_wdgGetErrorStatus(Pmic_CoreHandle_t *handle, Pmic_WdgError_t *error
     /* Extract watchdog error status fields */
     if (status == PMIC_ST_SUCCESS) {
         if (Pmic_validParamCheck(errors->validParams, PMIC_CFG_WD_LONGWIN_TIMEOUT_ERR_VALID)) {
-            errors->longWindowTimeout = Pmic_getBitField_b(regVal,
-                PMIC_WD_LONGWIN_TMO_SHIFT,
-                PMIC_WD_LONGWIN_TMO_MASK);
+            errors->longWindowTimeout = Pmic_getBitField_b(regVal, PMIC_WD_LONGWIN_TMO_SHIFT);
         }
 
         if (Pmic_validParamCheck(errors->validParams, PMIC_CFG_WD_TIMEOUT_ERR_VALID)) {
-            errors->timeout = Pmic_getBitField_b(regVal,
-                PMIC_WD_TMO_SHIFT,
-                PMIC_WD_TMO_MASK);
+            errors->timeout = Pmic_getBitField_b(regVal, PMIC_WD_TMO_SHIFT);
         }
 
         if (Pmic_validParamCheck(errors->validParams, PMIC_CFG_WD_TRIG_EARLY_ERR_VALID)) {
-            errors->triggerEarlyError = Pmic_getBitField_b(regVal,
-                PMIC_WD_TRIG_EARLY_SHIFT,
-                PMIC_WD_TRIG_EARLY_MASK);
+            errors->triggerEarlyError = Pmic_getBitField_b(regVal, PMIC_WD_TRIG_EARLY_SHIFT);
         }
 
         if (Pmic_validParamCheck(errors->validParams, PMIC_CFG_WD_ANSW_EARLY_ERR_VALID)) {
-            errors->answerEarlyError = Pmic_getBitField_b(regVal,
-                PMIC_WD_ANSW_EARLY_SHIFT,
-                PMIC_WD_ANSW_EARLY_MASK);
+            errors->answerEarlyError = Pmic_getBitField_b(regVal, PMIC_WD_ANSW_EARLY_SHIFT);
         }
 
         if (Pmic_validParamCheck(errors->validParams, PMIC_CFG_WD_SEQ_ERR_ERR_VALID)) {
-            errors->sequenceError = Pmic_getBitField_b(regVal,
-                PMIC_WD_SEQ_ERR_SHIFT,
-                PMIC_WD_SEQ_ERR_MASK);
+            errors->sequenceError = Pmic_getBitField_b(regVal, PMIC_WD_SEQ_ERR_SHIFT);
         }
 
         if (Pmic_validParamCheck(errors->validParams, PMIC_CFG_WD_ANSW_ERR_ERR_VALID)) {
-            errors->answerError = Pmic_getBitField_b(regVal,
-                PMIC_WD_ANSW_ERR_SHIFT,
-                PMIC_WD_ANSW_ERR_MASK);
+            errors->answerError = Pmic_getBitField_b(regVal, PMIC_WD_ANSW_ERR_SHIFT);
         }
 
         if (Pmic_validParamCheck(errors->validParams, PMIC_CFG_WD_TH1_INT_ERR_VALID)) {
-            errors->threshold1Error = Pmic_getBitField_b(regVal,
-                PMIC_WD_TH1_ERR_SHIFT,
-                PMIC_WD_TH1_ERR_MASK);
+            errors->threshold1Error = Pmic_getBitField_b(regVal, PMIC_WD_TH1_ERR_SHIFT);
         }
 
         if (Pmic_validParamCheck(errors->validParams, PMIC_CFG_WD_TH2_INT_ERR_VALID)) {
-            errors->threshold2Error = Pmic_getBitField_b(regVal,
-                PMIC_WD_TH2_ERR_SHIFT,
-                PMIC_WD_TH2_ERR_MASK);
+            errors->threshold2Error = Pmic_getBitField_b(regVal, PMIC_WD_TH2_ERR_SHIFT);
         }
     }
 
@@ -762,44 +746,35 @@ int32_t Pmic_wdgClrErrStatus(Pmic_CoreHandle_t *handle, const Pmic_WdgError_t *e
 
     if (status == PMIC_ST_SUCCESS) {
         if (Pmic_validParamCheck(errors->validParams, PMIC_CFG_WD_LONGWIN_TIMEOUT_ERR_VALID)) {
-            Pmic_setBitField_b(&regVal,
-                PMIC_WD_LONGWIN_TMO_SHIFT,
-                PMIC_WD_LONGWIN_TMO_MASK,
-                errors->longWindowTimeout);
+            Pmic_setBitField_b(&regVal, PMIC_WD_LONGWIN_TMO_SHIFT, errors->longWindowTimeout);
         }
 
         if (Pmic_validParamCheck(errors->validParams, PMIC_CFG_WD_TIMEOUT_ERR_VALID)) {
-            Pmic_setBitField_b(&regVal, PMIC_WD_TMO_SHIFT, PMIC_WD_TMO_MASK, errors->timeout);
+            Pmic_setBitField_b(&regVal, PMIC_WD_TMO_SHIFT, errors->timeout);
         }
 
         if (Pmic_validParamCheck(errors->validParams, PMIC_CFG_WD_TRIG_EARLY_ERR_VALID)) {
-            Pmic_setBitField_b(&regVal,
-                PMIC_WD_TRIG_EARLY_SHIFT,
-                PMIC_WD_TRIG_EARLY_MASK,
-                errors->triggerEarlyError);
+            Pmic_setBitField_b(&regVal, PMIC_WD_TRIG_EARLY_SHIFT, errors->triggerEarlyError);
         }
 
         if (Pmic_validParamCheck(errors->validParams, PMIC_CFG_WD_ANSW_EARLY_ERR_VALID)) {
-            Pmic_setBitField_b(&regVal,
-                PMIC_WD_ANSW_EARLY_SHIFT,
-                PMIC_WD_ANSW_EARLY_MASK,
-                errors->answerEarlyError);
+            Pmic_setBitField_b(&regVal, PMIC_WD_ANSW_EARLY_SHIFT, errors->answerEarlyError);
         }
 
         if (Pmic_validParamCheck(errors->validParams, PMIC_CFG_WD_SEQ_ERR_ERR_VALID)) {
-            Pmic_setBitField_b(&regVal, PMIC_WD_SEQ_ERR_SHIFT, PMIC_WD_SEQ_ERR_MASK, errors->sequenceError);
+            Pmic_setBitField_b(&regVal, PMIC_WD_SEQ_ERR_SHIFT, errors->sequenceError);
         }
 
         if (Pmic_validParamCheck(errors->validParams, PMIC_CFG_WD_ANSW_ERR_ERR_VALID)) {
-            Pmic_setBitField_b(&regVal, PMIC_WD_ANSW_ERR_SHIFT, PMIC_WD_ANSW_ERR_MASK, errors->answerError);
+            Pmic_setBitField_b(&regVal, PMIC_WD_ANSW_ERR_SHIFT, errors->answerError);
         }
 
         if (Pmic_validParamCheck(errors->validParams, PMIC_CFG_WD_TH1_INT_ERR_VALID)) {
-            Pmic_setBitField_b(&regVal, PMIC_WD_TH1_ERR_SHIFT, PMIC_WD_TH1_ERR_MASK, errors->threshold1Error);
+            Pmic_setBitField_b(&regVal, PMIC_WD_TH1_ERR_SHIFT, errors->threshold1Error);
         }
 
         if (Pmic_validParamCheck(errors->validParams, PMIC_CFG_WD_TH2_INT_ERR_VALID)) {
-            Pmic_setBitField_b(&regVal, PMIC_WD_TH2_ERR_SHIFT, PMIC_WD_TH2_ERR_MASK, errors->threshold2Error);
+            Pmic_setBitField_b(&regVal, PMIC_WD_TH2_ERR_SHIFT, errors->threshold2Error);
         }
     }
 
@@ -843,12 +818,12 @@ int32_t Pmic_wdgGetFailCntStat(Pmic_CoreHandle_t *handle, Pmic_WdgFailCntStat_t 
 
     /* Get watchdog Bad Event status */
     if (Pmic_validParamStatusCheck(failCount->validParams, PMIC_CFG_WD_BAD_EVENT_STAT_VALID, status)) {
-        failCount->badEvent = Pmic_getBitField_b(regVal, PMIC_WD_BAD_EVENT_SHIFT, PMIC_WD_BAD_EVENT_MASK);
+        failCount->badEvent = Pmic_getBitField_b(regVal, PMIC_WD_BAD_EVENT_SHIFT);
     }
 
     /* Get watchdog Good Event status */
     if (Pmic_validParamStatusCheck(failCount->validParams, PMIC_CFG_WD_GOOD_EVENT_STAT_VALID, status)) {
-        failCount->goodEvent = Pmic_getBitField_b(regVal, PMIC_WD_FIRST_OK_SHIFT, PMIC_WD_FIRST_OK_MASK);
+        failCount->goodEvent = Pmic_getBitField_b(regVal, PMIC_WD_FIRST_OK_SHIFT);
     }
 
     /* Get watchdog Fail count Value */


### PR DESCRIPTION
Add support for the following IRQ related APIs:
- Pmic_irqSetCfg()
- Pmic_irqSetCfgs()
- Pmic_irqGetCfg()
- Pmic_irqGetCfgs()
- Pmic_irqGetStat()
- Pmic_irqGetNextFlag()
- Pmic_irqGetFlag()
- Pmic_irqClrFlag()
- Pmic_irqClrAllFlags()